### PR TITLE
cli: forward GitHub Actions context as X-CI-* headers when in CI

### DIFF
--- a/internal/api/ci_headers.go
+++ b/internal/api/ci_headers.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+// setCIHeaders attaches X-CI-* headers when the CLI is invoked from a GitHub
+// Actions runner. Detection is gated on GITHUB_ACTIONS=true; outside CI this
+// function is a no-op so manual CLI usage stays unchanged.
+//
+// The PR URL and number are read from the event payload at GITHUB_EVENT_PATH
+// (only present on pull_request events). Missing values are omitted rather
+// than sent as empty headers.
+func setCIHeaders(req *http.Request) {
+	if os.Getenv("GITHUB_ACTIONS") != "true" {
+		return
+	}
+
+	server := os.Getenv("GITHUB_SERVER_URL")
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	actor := os.Getenv("GITHUB_ACTOR")
+	sha := os.Getenv("GITHUB_SHA")
+	branch := os.Getenv("GITHUB_REF_NAME")
+	runID := os.Getenv("GITHUB_RUN_ID")
+
+	setIf(req, "X-CI-System", "github-actions")
+	setIf(req, "X-CI-Commit-SHA", sha)
+	setIf(req, "X-CI-Branch", branch)
+	setIf(req, "X-CI-Run-ID", runID)
+	setIf(req, "X-CI-Repository", repo)
+	setIf(req, "X-CI-Actor", actor)
+
+	if server != "" && actor != "" {
+		setIf(req, "X-CI-Actor-URL", server+"/"+actor)
+	}
+	if server != "" && repo != "" && runID != "" {
+		setIf(req, "X-CI-Run-URL", server+"/"+repo+"/actions/runs/"+runID)
+	}
+
+	prURL, prNum := readPullRequestFromEvent(os.Getenv("GITHUB_EVENT_PATH"))
+	setIf(req, "X-CI-PR-URL", prURL)
+	if prNum > 0 {
+		setIf(req, "X-CI-PR-Number", strconv.Itoa(prNum))
+	}
+}
+
+func setIf(req *http.Request, key, value string) {
+	if value != "" {
+		req.Header.Set(key, value)
+	}
+}
+
+// readPullRequestFromEvent parses the GitHub event payload JSON for the
+// triggering pull request URL and number. Returns zero values for non-PR
+// events (push, schedule, workflow_dispatch) or unreadable payloads.
+func readPullRequestFromEvent(eventPath string) (string, int) {
+	if eventPath == "" {
+		return "", 0
+	}
+	data, err := os.ReadFile(eventPath)
+	if err != nil {
+		return "", 0
+	}
+	var payload struct {
+		PullRequest *struct {
+			HTMLURL string `json:"html_url"`
+			Number  int    `json:"number"`
+		} `json:"pull_request"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", 0
+	}
+	if payload.PullRequest == nil {
+		return "", 0
+	}
+	return payload.PullRequest.HTMLURL, payload.PullRequest.Number
+}

--- a/internal/api/ci_headers_integration_test.go
+++ b/internal/api/ci_headers_integration_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestExecuteWorkflow_SendsCIHeaders is a wire-level smoke test: it spins up a
+// fake backend, runs the real ExecuteWorkflow code path against it with
+// faked GitHub Actions env vars, and asserts the X-CI-* headers arrived
+// correctly. This is the closest we can get to option (a) without a real
+// staging backend / API key.
+func TestExecuteWorkflow_SendsCIHeaders(t *testing.T) {
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	prPayload := `{"pull_request":{"html_url":"https://github.com/acme/web/pull/482","number":482}}`
+	if err := os.WriteFile(eventPath, []byte(prPayload), 0o600); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("GITHUB_REPOSITORY", "acme/web")
+	t.Setenv("GITHUB_ACTOR", "janedoe")
+	t.Setenv("GITHUB_SHA", "9f2c1ab0")
+	t.Setenv("GITHUB_REF_NAME", "feat/checkout-rework")
+	t.Setenv("GITHUB_RUN_ID", "12345")
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	var captured http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Snapshot headers off the request before responding.
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"task_id": "abc-123",
+			"status":  "queued",
+		})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:        server.URL,
+		apiKey:         "test-key",
+		version:        "test",
+		httpClient:     &http.Client{Timeout: 5 * time.Second},
+		maxRetries:     0,
+		retryBaseDelay: time.Millisecond,
+		retryMaxDelay:  time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.ExecuteWorkflow(ctx, &ExecuteWorkflowRequest{
+		WorkflowID: "wf-abc",
+		Retries:    1,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteWorkflow: %v", err)
+	}
+	if resp.TaskID != "abc-123" {
+		t.Fatalf("task_id = %q, want abc-123", resp.TaskID)
+	}
+
+	want := map[string]string{
+		"X-Revyl-Client":  "cli",
+		"X-Ci-System":     "github-actions",
+		"X-Ci-Commit-Sha": "9f2c1ab0",
+		"X-Ci-Branch":     "feat/checkout-rework",
+		"X-Ci-Run-Id":     "12345",
+		"X-Ci-Repository": "acme/web",
+		"X-Ci-Actor":      "janedoe",
+		"X-Ci-Actor-Url":  "https://github.com/janedoe",
+		"X-Ci-Run-Url":    "https://github.com/acme/web/actions/runs/12345",
+		"X-Ci-Pr-Url":     "https://github.com/acme/web/pull/482",
+		"X-Ci-Pr-Number":  "482",
+	}
+	for key, expected := range want {
+		got := captured.Get(key)
+		if got != expected {
+			t.Errorf("header %s = %q, want %q", key, got, expected)
+		}
+	}
+
+	if got := captured.Get("Authorization"); got != "Bearer test-key" {
+		t.Errorf("Authorization = %q", got)
+	}
+}
+
+// TestExecuteWorkflow_NoCIHeadersOutsideActions confirms manual CLI runs are
+// completely unchanged — no X-CI-* headers leak into the request.
+func TestExecuteWorkflow_NoCIHeadersOutsideActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+
+	var captured http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"task_id": "abc-123"})
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL:        server.URL,
+		apiKey:         "test-key",
+		version:        "test",
+		httpClient:     &http.Client{Timeout: 5 * time.Second},
+		maxRetries:     0,
+		retryBaseDelay: time.Millisecond,
+		retryMaxDelay:  time.Millisecond,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := client.ExecuteWorkflow(ctx, &ExecuteWorkflowRequest{WorkflowID: "wf-abc"}); err != nil {
+		t.Fatalf("ExecuteWorkflow: %v", err)
+	}
+
+	for key := range captured {
+		if len(key) >= 5 && (key[:5] == "X-Ci-" || key[:5] == "X-CI-") {
+			t.Errorf("unexpected CI header outside Actions: %s = %q", key, captured.Get(key))
+		}
+	}
+	// Sanity: X-Revyl-Client always sent.
+	if got := captured.Get("X-Revyl-Client"); got != "cli" {
+		t.Errorf("X-Revyl-Client = %q, want cli", got)
+	}
+}

--- a/internal/api/ci_headers_test.go
+++ b/internal/api/ci_headers_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetCIHeaders_NotInActions(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "")
+
+	req := httptest.NewRequest("POST", "http://example.test", nil)
+	setCIHeaders(req)
+
+	if got := req.Header.Get("X-CI-System"); got != "" {
+		t.Fatalf("expected no X-CI-System header outside Actions, got %q", got)
+	}
+}
+
+func TestSetCIHeaders_PullRequest(t *testing.T) {
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	payload := `{"pull_request":{"html_url":"https://github.com/acme/web/pull/482","number":482}}`
+	if err := os.WriteFile(eventPath, []byte(payload), 0o600); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("GITHUB_REPOSITORY", "acme/web")
+	t.Setenv("GITHUB_ACTOR", "janedoe")
+	t.Setenv("GITHUB_SHA", "9f2c1ab0")
+	t.Setenv("GITHUB_REF_NAME", "feat/cool")
+	t.Setenv("GITHUB_RUN_ID", "12345")
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	req := httptest.NewRequest("POST", "http://example.test", nil)
+	setCIHeaders(req)
+
+	checks := map[string]string{
+		"X-CI-System":     "github-actions",
+		"X-CI-Commit-SHA": "9f2c1ab0",
+		"X-CI-Branch":     "feat/cool",
+		"X-CI-Run-ID":     "12345",
+		"X-CI-Repository": "acme/web",
+		"X-CI-Actor":      "janedoe",
+		"X-CI-Actor-URL":  "https://github.com/janedoe",
+		"X-CI-Run-URL":    "https://github.com/acme/web/actions/runs/12345",
+		"X-CI-PR-URL":     "https://github.com/acme/web/pull/482",
+		"X-CI-PR-Number":  "482",
+	}
+	for key, want := range checks {
+		if got := req.Header.Get(key); got != want {
+			t.Errorf("%s = %q, want %q", key, got, want)
+		}
+	}
+}
+
+func TestSetCIHeaders_PushEvent_NoPR(t *testing.T) {
+	dir := t.TempDir()
+	eventPath := filepath.Join(dir, "event.json")
+	if err := os.WriteFile(eventPath, []byte(`{"head_commit":{"id":"abc"}}`), 0o600); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("GITHUB_REPOSITORY", "acme/web")
+	t.Setenv("GITHUB_ACTOR", "janedoe")
+	t.Setenv("GITHUB_SHA", "9f2c1ab0")
+	t.Setenv("GITHUB_REF_NAME", "main")
+	t.Setenv("GITHUB_RUN_ID", "12345")
+	t.Setenv("GITHUB_EVENT_PATH", eventPath)
+
+	req := httptest.NewRequest("POST", "http://example.test", nil)
+	setCIHeaders(req)
+
+	if got := req.Header.Get("X-CI-PR-URL"); got != "" {
+		t.Errorf("expected no X-CI-PR-URL on push, got %q", got)
+	}
+	if got := req.Header.Get("X-CI-PR-Number"); got != "" {
+		t.Errorf("expected no X-CI-PR-Number on push, got %q", got)
+	}
+	if got := req.Header.Get("X-CI-Commit-SHA"); got != "9f2c1ab0" {
+		t.Errorf("X-CI-Commit-SHA = %q, want 9f2c1ab0", got)
+	}
+}
+
+func TestSetCIHeaders_MissingEventPath(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+	t.Setenv("GITHUB_SERVER_URL", "https://github.com")
+	t.Setenv("GITHUB_REPOSITORY", "acme/web")
+	t.Setenv("GITHUB_ACTOR", "")
+	t.Setenv("GITHUB_SHA", "")
+	t.Setenv("GITHUB_REF_NAME", "")
+	t.Setenv("GITHUB_RUN_ID", "")
+	t.Setenv("GITHUB_EVENT_PATH", "")
+
+	req := httptest.NewRequest("POST", "http://example.test", nil)
+	setCIHeaders(req)
+
+	// Still sets the system marker even when most context is missing.
+	if got := req.Header.Get("X-CI-System"); got != "github-actions" {
+		t.Errorf("X-CI-System = %q, want github-actions", got)
+	}
+	// Empty values are not sent.
+	if got := req.Header.Get("X-CI-Actor"); got != "" {
+		t.Errorf("expected no X-CI-Actor when GITHUB_ACTOR empty, got %q", got)
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -311,6 +311,7 @@ func (c *Client) doRequestOnce(ctx context.Context, method, path string, body in
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", c.userAgent())
 	req.Header.Set("X-Revyl-Client", "cli")
+	setCIHeaders(req)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -414,6 +415,7 @@ func (c *Client) doRequestWithRetry(ctx context.Context, method, path string, bo
 		// Set source tracking header
 		// X-Revyl-Client identifies the client type (cli maps to "api" source in DB)
 		req.Header.Set("X-Revyl-Client", "cli")
+		setCIHeaders(req)
 
 		// Execute the request
 		resp, err := c.httpClient.Do(req)


### PR DESCRIPTION
## Summary

- Customer Slack notifications for workflow runs triggered from a GitHub Action don't currently include the PR they were triggered from.
- This change makes the CLI auto-detect `GITHUB_ACTIONS=true` and attach the actor, PR URL/number, commit SHA, branch, repo, and run URL to outgoing API requests as `X-CI-*` headers.
- The backend persists these on `workflow_executions.source_metadata` and renders them as a trailing context line in the Slack message — paired with https://github.com/RevylAI/cognisim-monorepo/pull/1942.

Manual CLI usage (no `GITHUB_ACTIONS` env var) is byte-identical to before.

## Test plan

- [x] 4 unit tests covering PR event, push event, missing event path, and outside-Actions
- [x] 2 wire-level integration tests via `httptest.Server` confirming `client.ExecuteWorkflow` actually sends the right headers (and sends none outside Actions)
- [x] `go build ./...` clean, `go vet` clean

Would love a quick review.