### PR TITLE
Fixes Ci/CD URL on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Use the revyl-cli-auth-bypass skill. Set up test-only auth bypass for this app a
 | Cloud devices | `revyl device start` | [Commands](docs/COMMANDS.md#device-management) |
 | Dev loop (Expo) | `revyl dev` | [Commands](docs/COMMANDS.md#dev-loop-expo) |
 | Build and upload | `revyl build upload` | [Commands](docs/COMMANDS.md#build-management) |
-| CI/CD | GitHub Actions | [CI/CD](docs/CI_CD.md) |
+| CI/CD | GitHub Actions | [CI/CD](docs/ci-cd.md) |
 | Device SDK | `pip install revyl[sdk]` | [Device SDK](docs/SDK.md) |
 | Agent skills | `revyl skill install` | [Skills](docs/integrations/skills.md) |
 


### PR DESCRIPTION
Hey,

The CI/CD URL on the root `README.md` uses a `_` instead of `-` and it's broken because of that.

For consistency with the target filaname I also made it lowercase.