### PR TITLE
Split install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,28 @@ Revyl is an AI-powered testing platform for mobile apps. Define tests in natural
 
 ## Install
 
+### sh
+
 ```bash
-curl -fsSL https://revyl.com/install.sh | sh  # Shell (macOS / Linux)
-brew install RevylAI/tap/revyl          # Homebrew (macOS)
-pipx install revyl                      # pipx (cross-platform)
-uv tool install revyl                   # uv
+curl -fsSL https://revyl.com/install.sh | sh
+```
+
+### Homebrew (macOS)
+
+```bash
+brew install RevylAI/tap/revyl
+```
+
+### pipx (cross-platform)
+
+```bash
+pipx install revyl
+```
+
+### ux 
+
+```bash
+uv tool install revyl
 ```
 
 ## Authenticate


### PR DESCRIPTION
Just a minor suggestion, I'm so used to copy-pasta a block on the install, that only a second after I started running it, I realised I was doing it wrong. Just to avoid user error in this case I'm suggesting splitting them into single bash blocks for copy paste. Arguable if better or not, so feel free to close the PR if you think this adds nothing.