### PR TITLE
feat(hotreload): scaffold Flutter hot reload via reverse relay (gated)

### DIFF
--- a/cmd/revyl/dev.go
+++ b/cmd/revyl/dev.go
@@ -1469,6 +1469,9 @@ func runDevFlutterAttach(cwd string) error {
 	mgr.SetDevLoopStyle(hotreload.DevLoopStyleAttach)
 	mgr.SetExternalDebugURL(debugURL)
 	mgr.SetAttachDeviceID(strings.TrimSpace(os.Getenv("REVYL_FLUTTER_DEVICE")))
+	mgr.SetAttachRebuildHandler(func(files []string) {
+		ui.PrintWarning("Native/dependency change detected (%s) — hot reload can't apply this; a full rebuild + reinstall is required.", formatChangedFiles(files))
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1479,16 +1482,45 @@ func runDevFlutterAttach(cwd string) error {
 	}
 	defer mgr.Stop()
 
-	ui.PrintSuccess("Flutter hot reload active. Edit .dart files to reload; press Ctrl+C to stop.")
+	ui.PrintSuccess("Flutter hot reload active. Edit .dart files to reload.")
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigChan)
-	<-sigChan
 
-	ui.Println()
-	ui.PrintInfo("Stopping Flutter hot reload...")
-	return nil
+	stdinKeys, restore, _ := readStdinKeys(ctx, func() {
+		select {
+		case sigChan <- os.Interrupt:
+		default:
+		}
+	})
+	defer restore()
+
+	ui.PrintDim("  [r] hot reload    [R] hot restart    [q]/Ctrl+C quit")
+
+	for {
+		select {
+		case <-sigChan:
+			ui.Println()
+			ui.PrintInfo("Stopping Flutter hot reload...")
+			return nil
+		case key := <-stdinKeys:
+			switch key {
+			case 'r':
+				if err := mgr.Reload(ctx); err != nil {
+					ui.PrintWarning("Hot reload failed: %v", err)
+				}
+			case 'R':
+				if err := mgr.HotRestart(ctx); err != nil {
+					ui.PrintWarning("Hot restart failed: %v", err)
+				}
+			case 'q':
+				ui.Println()
+				ui.PrintInfo("Stopping Flutter hot reload...")
+				return nil
+			}
+		}
+	}
 }
 
 // devSessionViewerURL returns the canonical session viewer route for the active

--- a/cmd/revyl/dev.go
+++ b/cmd/revyl/dev.go
@@ -454,6 +454,22 @@ func runDevStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("`revyl dev` is for local development loops. In CI, use `revyl test run` or `revyl device start`")
 	}
 
+	// Experimental: Flutter attach-based hot reload, opted in via
+	// REVYL_FLUTTER_HOT_RELOAD. The local path needs no auth or relay, so it
+	// short-circuits the standard dev-loop setup. Dormant by default; other
+	// stacks are unaffected.
+	if flutterAttachHotReloadEnabled() {
+		root, rootErr := os.Getwd()
+		if rootErr == nil {
+			if repoRoot, frErr := config.FindRepoRoot(root); frErr == nil {
+				root = repoRoot
+			}
+			if isFlutterAttachProject(root) {
+				return runDevFlutterAttach(root)
+			}
+		}
+	}
+
 	apiKey, err := getAPIKey()
 	if err != nil {
 		return err
@@ -1407,6 +1423,72 @@ func runDevStart(cmd *cobra.Command, args []string) error {
 func isCIEnvironment() bool {
 	return strings.TrimSpace(os.Getenv("CI")) != "" ||
 		strings.TrimSpace(os.Getenv("GITHUB_ACTIONS")) != ""
+}
+
+// flutterAttachHotReloadEnabled reports whether the experimental Flutter
+// attach-based hot reload loop is opted in via REVYL_FLUTTER_HOT_RELOAD.
+//
+// It is off by default. The cloud path additionally requires backend
+// reverse-relay support and VM Service port discovery (not yet available); the
+// local path attaches to a running VM Service via REVYL_FLUTTER_DEBUG_URL.
+func flutterAttachHotReloadEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("REVYL_FLUTTER_HOT_RELOAD"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// isFlutterAttachProject reports whether the directory is a Flutter project that
+// uses the attach-based dev loop.
+func isFlutterAttachProject(cwd string) bool {
+	provider, _, err := hotreload.DefaultRegistry().DetectProvider(cwd)
+	if err != nil || provider == nil {
+		return false
+	}
+	return provider.Name() == "flutter" &&
+		hotreload.ProviderDevLoopStyle(provider) == hotreload.DevLoopStyleAttach
+}
+
+// runDevFlutterAttach runs the experimental Flutter attach-based hot reload loop.
+//
+// The Manager owns the full loop (attach + file watch + reload). Cloud device
+// discovery is not available yet, so this currently requires a local VM Service
+// URL via REVYL_FLUTTER_DEBUG_URL (optionally REVYL_FLUTTER_DEVICE to select a
+// device). See docs/developer_loop/flutter-hot-reload-design.md.
+func runDevFlutterAttach(cwd string) error {
+	debugURL := strings.TrimSpace(os.Getenv("REVYL_FLUTTER_DEBUG_URL"))
+	if debugURL == "" {
+		return fmt.Errorf("experimental Flutter hot reload requires a local VM Service URL via REVYL_FLUTTER_DEBUG_URL; cloud device discovery is not available yet (see docs/developer_loop/flutter-hot-reload-design.md)")
+	}
+
+	mgr := hotreload.NewManager("flutter", &config.ProviderConfig{}, cwd)
+	mgr.SetLogCallback(func(msg string) { ui.PrintInfo("%s", msg) })
+	mgr.SetDevServerOutputCallback(func(o hotreload.DevServerOutput) { ui.PrintDim("  %s", o.Line) })
+	mgr.SetDevLoopStyle(hotreload.DevLoopStyleAttach)
+	mgr.SetExternalDebugURL(debugURL)
+	mgr.SetAttachDeviceID(strings.TrimSpace(os.Getenv("REVYL_FLUTTER_DEVICE")))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ui.PrintInfo("Starting experimental Flutter hot reload (attach)...")
+	if _, err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start Flutter hot reload: %w", err)
+	}
+	defer mgr.Stop()
+
+	ui.PrintSuccess("Flutter hot reload active. Edit .dart files to reload; press Ctrl+C to stop.")
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+	<-sigChan
+
+	ui.Println()
+	ui.PrintInfo("Stopping Flutter hot reload...")
+	return nil
 }
 
 // devSessionViewerURL returns the canonical session viewer route for the active

--- a/docs/developer_loop/flutter-hot-reload-design.md
+++ b/docs/developer_loop/flutter-hot-reload-design.md
@@ -1,0 +1,148 @@
+# Flutter hot reload via reverse forwarding — design & backend contract
+
+Status: **CLI scaffolding landed (gated off); backend work required to enable.**
+
+## Why this exists
+
+Revyl streams code to cloud devices for JS frameworks (Expo / React Native) but
+rebuilds Flutter on every change. The blocker is not Flutter — Flutter has
+first-class hot reload — but the **direction** of Revyl's relay.
+
+- **JS (works today):** Metro runs on the laptop; the **device pulls** the
+  bundle. The relay is built for exactly this — the device opens a connection
+  and the backend forwards it to a port on the laptop.
+- **Flutter (stock):** `flutter attach` runs on the laptop and **connects into**
+  the Dart VM Service that the running app exposes **on the device**. The host
+  is the client; the device is the server.
+
+So Flutter needs the laptop to reach a port **on the device** — the mirror image
+of what the relay does today. We call that **reverse forwarding**.
+
+The data plane is already bidirectional (the relay carries websocket frames both
+ways). The missing capability is **connection initiation**: today only the
+device can open a stream, and the relay only ever dials a port on the laptop.
+Reverse mode adds laptop-initiated streams whose target is a device-side port.
+
+## Architecture
+
+```
+FileWatcher ──▶ FlutterAttachDevServer.Reload()  (sends "r" to flutter attach)
+                         │
+                 flutter attach --debug-url http://127.0.0.1:NNN/
+                         │ dials
+                         ▼
+        ReverseRelayTunnelBackend  (local TCP listener 127.0.0.1:NNN)
+                         │ proxies raw bytes over the relay websocket
+                         ▼
+        Revyl backend (REVERSE MODE)  ──▶ dials device VM Service port
+                         ▼
+                 Dart VM Service (on the cloud device, debug build)
+```
+
+The proxy is **raw TCP**, so it transparently carries the VM Service's HTTP
+upgrade and websocket frames — no protocol awareness needed in the relay.
+
+## What this PR lands (CLI, `revyl-cli`)
+
+All additive and **gated** behind `FlutterProvider.IsSupported() == false`, so
+user-facing behavior is unchanged (Flutter still routes to the rebuild loop).
+
+| Area | File | What |
+|------|------|------|
+| Reverse tunnel contract | `internal/hotreload/tunnel.go` | `ReverseTunnelBackend` interface |
+| Reload contract | `internal/hotreload/devserver.go` | `Reloadable` interface |
+| Reverse proxy | `internal/hotreload/reverse_relay.go` | `ReverseRelayTunnelBackend` (local listener ↔ relay) |
+| Attach dev server | `internal/hotreload/providers/flutter_devserver.go` | `FlutterAttachDevServer` (drives `flutter attach`) |
+| Provider wiring | `internal/hotreload/providers/flutter_provider.go` | `CreateDevServer`, `DevLoopStyle() == "attach"` |
+| Dev-loop styles | `internal/hotreload/provider.go` | `ProviderDevLoopStyler`, `ProviderDevLoopStyle()` |
+| API params | `internal/api/client.go` | `Mode`, `DevicePort`, `DeviceVMServicePort` |
+
+### Still TODO in the CLI (follow-up PRs, after backend lands)
+1. **Manager attach branch** — in `Manager.Start` ([manager.go]), add an
+   `attach`-style path: discover device VM Service port → `StartReverse` →
+   `SetDebugURL` → `flutter attach`. Reuse the existing health/reconnect path.
+2. **`revyl dev` routing** — flip Flutter off the rebuild loop when the backend
+   advertises reverse support; keep rebuild as graceful fallback.
+3. **File-change classification** — `*.dart` → reload; `pubspec.yaml`/native →
+   fall back to rebuild. Reuse `FlutterWatchConfig()`.
+4. **Debug build variant** — ensure the dev build is `--debug` with the VM
+   Service enabled, marked hot-reload-capable.
+5. **Flip `IsSupported()` → true** and update the support tables in
+   `dev-setup.md`, `builds/index.md`, `dev-loop.md`.
+
+## Backend contract (work required outside this repo)
+
+### 1. Reverse-mode relay sessions
+
+`POST /api/v1/hotreload/relays` accepts new fields:
+
+```jsonc
+{
+  "provider": "flutter",
+  "platform": "ios",
+  "mode": "reverse",        // NEW — "forward" (default) | "reverse"
+  "device_port": 0          // NEW — VM Service port to dial; see discovery
+}
+```
+
+Response may include:
+
+```jsonc
+{
+  "relay_id": "...",
+  "connect_url": "wss://...",
+  "connect_token": "...",
+  "transport": "reverse",
+  "device_vm_service_port": 54321   // NEW — discovered VM Service port
+}
+```
+
+In reverse mode the backend must:
+- accept **CLI-initiated** streams over the relay websocket, and
+- for each stream, **dial the device's VM Service port** and bridge bytes.
+
+### 2. Reverse data-plane protocol
+
+Reuses the existing envelope shape, with three kinds the **CLI sends** and the
+backend acts on (mirror of the forward `http.request.*` / `ws.*` kinds):
+
+| Kind | Direction | Meaning |
+|------|-----------|---------|
+| `device.dial.start` | CLI → backend | Open a new stream; backend dials the device VM Service port |
+| `device.dial.data`  | both ways | Base64 byte chunk for `stream_id` |
+| `device.dial.close` | both ways | Half/!full close for `stream_id` |
+| `stream.error`      | backend → CLI | Dial/transport error for `stream_id` |
+
+Framing matches forward mode: `stream_id`, `body_chunk_b64`, base64 chunks
+sized ~32 KiB. Heartbeat (`ping`/`pong`) is reused unchanged.
+
+### 3. VM Service discovery (device fleet)
+
+When a Flutter **debug** build launches on a cloud device, the fleet must:
+- launch with the Dart VM Service **enabled and listening** (debug/JIT),
+- discover its port/auth path, and
+- report it — either inline on the relay session (`device_vm_service_port`) or
+  via a separate poll endpoint. **Open question: which?**
+
+### 4. Auth
+
+Laptop-initiated streams into a device port are a new privilege. Reuse the relay
+`connect_token` (`ConnectAuthHeader`) and scope reverse sessions to the
+authenticated user's own device session.
+
+## Rollout / gating
+
+1. Backend ships reverse mode behind a capability flag.
+2. CLI flips `IsSupported()` only when the backend advertises reverse support
+   (so older backends keep the rebuild loop).
+3. Validate first against a **local emulator** (no relay) to de-risk the
+   attach + reload mechanics, then through the relay.
+
+## Open questions
+
+1. VM Service port discovery: inline on the session, or a separate poll?
+2. Reverse streams over the existing relay websocket (new kinds), or a separate
+   session type?
+3. iOS debug signing for VM-Service-enabled simulator builds.
+4. Reload vs hot-restart vs rebuild classification — owned by CLI, but the
+   fleet must support reinstall-less hot restart for the middle tier.

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -214,10 +214,32 @@ type APIError struct {
 	Hint string
 }
 
+// Relay transport modes.
+const (
+	// HotReloadRelayModeForward is the default device -> laptop transport used
+	// by the Metro/JS dev loop: the device dials a local port on the laptop.
+	HotReloadRelayModeForward = "forward"
+
+	// HotReloadRelayModeReverse is the laptop -> device transport used by
+	// attach-based dev loops (Flutter): the laptop dials a port on the device
+	// (the Dart VM Service). Requires backend support; see
+	// docs/developer_loop/flutter-hot-reload-design.md.
+	HotReloadRelayModeReverse = "reverse"
+)
+
 // HotReloadRelayCreateParams provisions a new backend-owned hot reload relay.
 type HotReloadRelayCreateParams struct {
 	Provider string `json:"provider,omitempty"`
 	Platform string `json:"platform,omitempty"`
+
+	// Mode selects the transport direction. Empty defaults to "forward" on the
+	// backend for backward compatibility. Set to HotReloadRelayModeReverse for
+	// attach-based providers.
+	Mode string `json:"mode,omitempty"`
+
+	// DevicePort is the port on the cloud device the relay should dial when
+	// Mode is "reverse" (the Dart VM Service port). Ignored for "forward".
+	DevicePort int `json:"device_port,omitempty"`
 }
 
 // HotReloadRelaySession describes a backend-owned hot reload relay session.
@@ -228,6 +250,11 @@ type HotReloadRelaySession struct {
 	ConnectToken string `json:"connect_token"`
 	Transport    string `json:"transport"`
 	ExpiresAt    string `json:"expires_at"`
+
+	// DeviceVMServicePort is populated for reverse-mode sessions when the
+	// backend has discovered the Dart VM Service port on the device. Zero when
+	// not yet known or not applicable.
+	DeviceVMServicePort int `json:"device_vm_service_port,omitempty"`
 }
 
 // ConnectWebSocketURL returns the relay websocket URL without embedding auth material.

--- a/internal/build/detect.go
+++ b/internal/build/detect.go
@@ -410,8 +410,13 @@ func detectFlutter(dir string) (*DetectedBuild, error) {
 		Platforms: make(map[string]BuildPlatform),
 	}
 
+	// Debug builds run the Dart VM in JIT mode with the VM Service enabled, which
+	// is required for `flutter attach` hot reload on cloud devices and also keeps
+	// the build debuggable for the State tab. This matches the documented Flutter
+	// artifact requirements (docs/builds/artifact-requirements.md). Android was
+	// already --debug; iOS previously defaulted to release.
 	detected.Platforms["ios"] = BuildPlatform{
-		Command: "flutter build ios --simulator",
+		Command: "flutter build ios --simulator --debug",
 		Output:  "build/ios/iphonesimulator/*.app",
 	}
 

--- a/internal/build/detect_flutter_test.go
+++ b/internal/build/detect_flutter_test.go
@@ -1,0 +1,29 @@
+package build
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDetectFlutterProducesDebugBuilds guards that the default Flutter build
+// commands produce debug artifacts. Debug builds enable the Dart VM Service
+// (required for `flutter attach` hot reload on cloud devices) and keep the
+// build debuggable for the State tab.
+func TestDetectFlutterProducesDebugBuilds(t *testing.T) {
+	t.Parallel()
+
+	detected, err := detectFlutter(t.TempDir())
+	if err != nil {
+		t.Fatalf("detectFlutter error = %v", err)
+	}
+
+	ios := detected.Platforms["ios"].Command
+	if !strings.Contains(ios, "--simulator") || !strings.Contains(ios, "--debug") {
+		t.Fatalf("ios command = %q, want a --simulator --debug build (VM Service for hot reload)", ios)
+	}
+
+	android := detected.Platforms["android"].Command
+	if !strings.Contains(android, "--debug") {
+		t.Fatalf("android command = %q, want a --debug build", android)
+	}
+}

--- a/internal/hotreload/devserver.go
+++ b/internal/hotreload/devserver.go
@@ -143,6 +143,14 @@ type DebugURLConfigurable interface {
 	SetDebugURL(debugURL string)
 }
 
+// DeviceIDConfigurable is implemented by attach-based dev servers that target a
+// specific device (e.g. Flutter's `attach -d <id>`, required when more than one
+// device is connected).
+type DeviceIDConfigurable interface {
+	// SetDeviceID sets the target device id. Must be called before Start.
+	SetDeviceID(deviceID string)
+}
+
 // Reloadable is implemented by attach-based dev servers (e.g. Flutter) that can
 // inject code into an already-running app without a full reinstall.
 //

--- a/internal/hotreload/devserver.go
+++ b/internal/hotreload/devserver.go
@@ -135,6 +135,14 @@ type DevServerFailureReporter interface {
 	Failures() <-chan RuntimeFailure
 }
 
+// DebugURLConfigurable is implemented by attach-based dev servers (e.g. Flutter)
+// that attach to a VM Service URL supplied after the dev server is created —
+// once the reverse tunnel (or local emulator address) is known.
+type DebugURLConfigurable interface {
+	// SetDebugURL sets the VM Service URL to attach to. Must be called before Start.
+	SetDebugURL(debugURL string)
+}
+
 // Reloadable is implemented by attach-based dev servers (e.g. Flutter) that can
 // inject code into an already-running app without a full reinstall.
 //

--- a/internal/hotreload/devserver.go
+++ b/internal/hotreload/devserver.go
@@ -135,6 +135,23 @@ type DevServerFailureReporter interface {
 	Failures() <-chan RuntimeFailure
 }
 
+// Reloadable is implemented by attach-based dev servers (e.g. Flutter) that can
+// inject code into an already-running app without a full reinstall.
+//
+// Unlike the Metro/JS dev loop — where the device pulls a fresh bundle and the
+// dev server is passive — attach-based providers actively drive reload and
+// restart against the running app. The hot-reload driver calls these in
+// response to file-change events.
+type Reloadable interface {
+	// Reload performs an in-place hot reload, preserving app state where the
+	// framework allows it (e.g. Flutter "r").
+	Reload(ctx context.Context) error
+
+	// HotRestart performs a hot restart, re-running the app from its entrypoint
+	// without reinstalling the binary (e.g. Flutter "R"). State is lost.
+	HotRestart(ctx context.Context) error
+}
+
 // DevServerStatus represents the current status of a development server.
 type DevServerStatus string
 

--- a/internal/hotreload/manager.go
+++ b/internal/hotreload/manager.go
@@ -38,11 +38,19 @@ type DevServerFactory func(workDir, appScheme string, port int, useExpPrefix boo
 // Simpler signature than DevServerFactory since bare RN has no app scheme or exp prefix.
 type BareRNDevServerFactory func(workDir string, port int) DevServer
 
+// FlutterAttachDevServerFactory creates a Flutter attach DevServer. The VM
+// Service debug URL is supplied later via DebugURLConfigurable.SetDebugURL,
+// once the reverse tunnel (or a local emulator address) is known.
+type FlutterAttachDevServerFactory func(workDir string) DevServer
+
 // expoDevServerFactory is set by the providers package during init.
 var expoDevServerFactory DevServerFactory
 
 // bareRNDevServerFactory is set by the providers package during init.
 var bareRNDevServerFactory BareRNDevServerFactory
+
+// flutterAttachDevServerFactory is set by the providers package during init.
+var flutterAttachDevServerFactory FlutterAttachDevServerFactory
 
 var postStartupDiagnostics = RunPostStartupDiagnosticsForPlatform
 var waitForExpoMetroTransport = WaitForExpoMetroTransport
@@ -68,6 +76,12 @@ func RegisterBareRNDevServerFactory(factory BareRNDevServerFactory) {
 	bareRNDevServerFactory = factory
 }
 
+// RegisterFlutterAttachDevServerFactory registers the Flutter attach dev server
+// factory. Called by the providers package during init.
+func RegisterFlutterAttachDevServerFactory(factory FlutterAttachDevServerFactory) {
+	flutterAttachDevServerFactory = factory
+}
+
 // TunnelBackendFactory creates a TunnelBackend for tests or custom wiring.
 type TunnelBackendFactory func() TunnelBackend
 
@@ -87,6 +101,26 @@ type Manager struct {
 
 	// tunnel is the active tunnel backend.
 	tunnel TunnelBackend
+
+	// reverseTunnel is the active reverse tunnel backend for attach-based dev
+	// loops (Flutter). It exposes the device's VM Service port locally.
+	reverseTunnel ReverseTunnelBackend
+
+	// devLoopStyle selects the orchestration in Start: "" / "metro" use the
+	// Metro relay path; "attach" uses the reverse-tunnel + flutter attach path.
+	devLoopStyle string
+
+	// deviceVMServicePort is the Dart VM Service port on the device to reverse
+	// forward for attach-based dev loops. Supplied by discovery (backend).
+	deviceVMServicePort int
+
+	// externalDebugURL, when set, bypasses the reverse tunnel and attaches
+	// directly to this VM Service URL. Used for local-emulator validation.
+	externalDebugURL string
+
+	// reverseTunnelFactory overrides the default ReverseTunnelBackend
+	// construction (for tests and custom wiring).
+	reverseTunnelFactory func() ReverseTunnelBackend
 
 	// apiClient is used by the relay transport control plane.
 	apiClient *api.Client
@@ -255,6 +289,32 @@ func (m *Manager) SetExternalDeepLinkURL(deepLinkURL string) {
 	m.externalDeepLinkURL = strings.TrimSpace(deepLinkURL)
 }
 
+// SetDevLoopStyle selects the dev-loop orchestration. Use DevLoopStyleAttach to
+// take the reverse-tunnel + flutter attach path; any other value uses the
+// default Metro path. Must be called before Start.
+func (m *Manager) SetDevLoopStyle(style string) {
+	m.devLoopStyle = strings.ToLower(strings.TrimSpace(style))
+}
+
+// SetDeviceVMServicePort sets the Dart VM Service port on the device to reverse
+// forward for attach-based dev loops. Must be called before Start.
+func (m *Manager) SetDeviceVMServicePort(port int) {
+	m.deviceVMServicePort = port
+}
+
+// SetExternalDebugURL attaches directly to the given VM Service URL, bypassing
+// the reverse tunnel. Used for local-emulator validation. Must be called before
+// Start.
+func (m *Manager) SetExternalDebugURL(debugURL string) {
+	m.externalDebugURL = strings.TrimSpace(debugURL)
+}
+
+// SetReverseTunnelBackendFactory overrides the default reverse tunnel backend
+// construction (for tests and custom wiring). Must be called before Start.
+func (m *Manager) SetReverseTunnelBackendFactory(factory func() ReverseTunnelBackend) {
+	m.reverseTunnelFactory = factory
+}
+
 // log sends a message to the log callback if set.
 func (m *Manager) log(format string, args ...interface{}) {
 	if m.onLog != nil {
@@ -303,6 +363,10 @@ func (m *Manager) Start(ctx context.Context) (result *StartResult, err error) {
 
 	if m.externalTunnelURL != "" {
 		return m.startExternal(m.ctx)
+	}
+
+	if m.devLoopStyle == DevLoopStyleAttach {
+		return m.startAttach(m.ctx)
 	}
 
 	// 1. Create dev server instance (but don't start yet - we need tunnel URL first)
@@ -560,6 +624,15 @@ func (m *Manager) cleanupLocked(logStopped bool) {
 		m.tunnel = nil
 		if logStopped {
 			m.log("Tunnel stopped")
+		}
+	}
+
+	// Stop reverse tunnel (attach-based dev loops)
+	if m.reverseTunnel != nil {
+		m.reverseTunnel.StopReverse()
+		m.reverseTunnel = nil
+		if logStopped {
+			m.log("Reverse tunnel stopped")
 		}
 	}
 
@@ -1152,6 +1225,79 @@ func (m *Manager) createDevServer() (DevServer, error) {
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", m.providerName)
 	}
+}
+
+// startAttach orchestrates the attach-based dev loop (Flutter). It establishes a
+// reverse tunnel to the device's Dart VM Service (or uses an external debug URL
+// for local-emulator validation), then launches `flutter attach` against it.
+//
+// Must be called with m.mu held (it is invoked from Start).
+func (m *Manager) startAttach(ctx context.Context) (*StartResult, error) {
+	m.log("Preparing %s attach dev server...", m.providerName)
+	devServer, err := m.createAttachDevServer()
+	if err != nil {
+		return nil, err
+	}
+	m.attachDevServerOutputCallback(devServer)
+
+	debugURL := m.externalDebugURL
+	transport := "external-attach"
+
+	if debugURL == "" {
+		if m.deviceVMServicePort <= 0 {
+			return nil, fmt.Errorf("attach hot reload requires a device VM Service port (discovery unavailable)")
+		}
+		backend := m.newReverseTunnelBackend()
+		localAddr, err := backend.StartReverse(ctx, m.deviceVMServicePort)
+		if err != nil {
+			return nil, fmt.Errorf("failed to start reverse tunnel: %w", err)
+		}
+		m.reverseTunnel = backend
+		debugURL = fmt.Sprintf("http://%s/", localAddr)
+		transport = "reverse-relay"
+		m.debugLog("Reverse tunnel ready: %s -> device port %d", debugURL, m.deviceVMServicePort)
+	}
+
+	setter, ok := devServer.(DebugURLConfigurable)
+	if !ok {
+		return nil, fmt.Errorf("attach dev server %q does not support debug URL configuration", devServer.Name())
+	}
+	setter.SetDebugURL(debugURL)
+
+	m.log("Starting %s attach...", m.providerName)
+	if err := devServer.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start attach dev server: %w", err)
+	}
+	m.devServer = devServer
+	m.running = true
+	m.log("%s attach ready", devServer.Name())
+
+	return &StartResult{
+		TunnelURL: debugURL,
+		Transport: transport,
+	}, nil
+}
+
+// createAttachDevServer builds the dev server for an attach-based provider.
+func (m *Manager) createAttachDevServer() (DevServer, error) {
+	switch m.providerName {
+	case "flutter":
+		if flutterAttachDevServerFactory == nil {
+			return nil, fmt.Errorf("flutter attach dev server factory not registered - import github.com/revyl/cli/internal/hotreload/providers")
+		}
+		return flutterAttachDevServerFactory(m.workDir), nil
+	default:
+		return nil, fmt.Errorf("attach dev loop is not supported for provider: %s", m.providerName)
+	}
+}
+
+// newReverseTunnelBackend constructs the reverse tunnel backend, honoring the
+// injected factory when present.
+func (m *Manager) newReverseTunnelBackend() ReverseTunnelBackend {
+	if m.reverseTunnelFactory != nil {
+		return m.reverseTunnelFactory()
+	}
+	return NewReverseRelayTunnelBackend(m.apiClient, m.providerName, m.targetPlatform)
 }
 
 // GetProviderName returns the provider name.

--- a/internal/hotreload/manager.go
+++ b/internal/hotreload/manager.go
@@ -118,6 +118,10 @@ type Manager struct {
 	// directly to this VM Service URL. Used for local-emulator validation.
 	externalDebugURL string
 
+	// attachDeviceID targets a specific device for the attach dev server
+	// (Flutter's `attach -d <id>`), required when multiple devices are present.
+	attachDeviceID string
+
 	// reverseTunnelFactory overrides the default ReverseTunnelBackend
 	// construction (for tests and custom wiring).
 	reverseTunnelFactory func() ReverseTunnelBackend
@@ -314,6 +318,12 @@ func (m *Manager) SetDeviceVMServicePort(port int) {
 // Start.
 func (m *Manager) SetExternalDebugURL(debugURL string) {
 	m.externalDebugURL = strings.TrimSpace(debugURL)
+}
+
+// SetAttachDeviceID targets a specific device for the attach dev server
+// (Flutter's `attach -d <id>`). Must be called before Start.
+func (m *Manager) SetAttachDeviceID(deviceID string) {
+	m.attachDeviceID = strings.TrimSpace(deviceID)
 }
 
 // SetReverseTunnelBackendFactory overrides the default reverse tunnel backend
@@ -1262,6 +1272,11 @@ func (m *Manager) startAttach(ctx context.Context) (*StartResult, error) {
 		return nil, err
 	}
 	m.attachDevServerOutputCallback(devServer)
+	if m.attachDeviceID != "" {
+		if cfg, ok := devServer.(DeviceIDConfigurable); ok {
+			cfg.SetDeviceID(m.attachDeviceID)
+		}
+	}
 
 	debugURL := m.externalDebugURL
 	transport := "external-attach"

--- a/internal/hotreload/manager.go
+++ b/internal/hotreload/manager.go
@@ -122,6 +122,13 @@ type Manager struct {
 	// construction (for tests and custom wiring).
 	reverseTunnelFactory func() ReverseTunnelBackend
 
+	// reloadWatcher is the file watcher driving the attach reload loop.
+	reloadWatcher *FileWatcher
+
+	// onAttachRebuild is invoked when an attach-loop change requires a full
+	// rebuild (pubspec/native). When nil, such changes are logged and skipped.
+	onAttachRebuild func(files []string)
+
 	// apiClient is used by the relay transport control plane.
 	apiClient *api.Client
 
@@ -313,6 +320,13 @@ func (m *Manager) SetExternalDebugURL(debugURL string) {
 // construction (for tests and custom wiring). Must be called before Start.
 func (m *Manager) SetReverseTunnelBackendFactory(factory func() ReverseTunnelBackend) {
 	m.reverseTunnelFactory = factory
+}
+
+// SetAttachRebuildHandler registers a callback invoked when an attach-loop file
+// change requires a full rebuild (pubspec/native changes the attach session
+// cannot apply). Must be called before Start.
+func (m *Manager) SetAttachRebuildHandler(fn func(files []string)) {
+	m.onAttachRebuild = fn
 }
 
 // log sends a message to the log callback if set.
@@ -633,6 +647,15 @@ func (m *Manager) cleanupLocked(logStopped bool) {
 		m.reverseTunnel = nil
 		if logStopped {
 			m.log("Reverse tunnel stopped")
+		}
+	}
+
+	// Stop the attach reload-loop file watcher
+	if m.reloadWatcher != nil {
+		m.reloadWatcher.Stop()
+		m.reloadWatcher = nil
+		if logStopped {
+			m.log("Reload watcher stopped")
 		}
 	}
 
@@ -1272,10 +1295,46 @@ func (m *Manager) startAttach(ctx context.Context) (*StartResult, error) {
 	m.running = true
 	m.log("%s attach ready", devServer.Name())
 
+	// Start the file-change reload loop so saving source hot reloads the device.
+	// Best-effort: a watcher failure degrades to manual reload, it does not abort
+	// the attach session.
+	m.startReloadLoop(ctx, devServer)
+
 	return &StartResult{
 		TunnelURL: debugURL,
 		Transport: transport,
 	}, nil
+}
+
+// startReloadLoop wires a file watcher to the attach dev server so that source
+// changes drive hot reload. It is a no-op if the dev server is not Reloadable,
+// and best-effort otherwise (watcher failures are logged, not fatal).
+func (m *Manager) startReloadLoop(ctx context.Context, devServer DevServer) {
+	target, ok := devServer.(Reloadable)
+	if !ok {
+		m.debugLog("attach dev server %q is not reloadable; skipping reload loop", devServer.Name())
+		return
+	}
+
+	driver, watcher, err := NewFlutterReloadDriver(m.workDir, target)
+	if err != nil {
+		m.log("Hot reload on save unavailable (watcher init failed: %v)", err)
+		return
+	}
+	if m.onLog != nil {
+		driver.SetLogCallback(m.onLog)
+	}
+	if m.onAttachRebuild != nil {
+		driver.SetRebuildHandler(m.onAttachRebuild)
+	}
+
+	if err := watcher.Start(ctx); err != nil {
+		m.log("Hot reload on save unavailable (watcher failed to start: %v)", err)
+		return
+	}
+	m.reloadWatcher = watcher
+	go func() { _ = driver.Run(ctx) }()
+	m.log("Watching %s for changes (hot reload on save)", m.workDir)
 }
 
 // createAttachDevServer builds the dev server for an attach-based provider.

--- a/internal/hotreload/manager.go
+++ b/internal/hotreload/manager.go
@@ -1374,6 +1374,41 @@ func (m *Manager) newReverseTunnelBackend() ReverseTunnelBackend {
 	return NewReverseRelayTunnelBackend(m.apiClient, m.providerName, m.targetPlatform)
 }
 
+// Reload triggers a manual hot reload on the active attach dev server.
+// It is an error if no reloadable dev server is running.
+func (m *Manager) Reload(ctx context.Context) error {
+	target, err := m.reloadable()
+	if err != nil {
+		return err
+	}
+	return target.Reload(ctx)
+}
+
+// HotRestart triggers a manual hot restart on the active attach dev server.
+// It is an error if no reloadable dev server is running.
+func (m *Manager) HotRestart(ctx context.Context) error {
+	target, err := m.reloadable()
+	if err != nil {
+		return err
+	}
+	return target.HotRestart(ctx)
+}
+
+// reloadable returns the active dev server as a Reloadable, or an error.
+func (m *Manager) reloadable() (Reloadable, error) {
+	m.mu.Lock()
+	devServer := m.devServer
+	m.mu.Unlock()
+	if devServer == nil {
+		return nil, fmt.Errorf("no active dev server")
+	}
+	target, ok := devServer.(Reloadable)
+	if !ok {
+		return nil, fmt.Errorf("dev server %q does not support hot reload", devServer.Name())
+	}
+	return target, nil
+}
+
 // GetProviderName returns the provider name.
 //
 // Returns:

--- a/internal/hotreload/manager_attach_test.go
+++ b/internal/hotreload/manager_attach_test.go
@@ -168,6 +168,37 @@ func TestStartAttachDrivesReloadOnFileChange(t *testing.T) {
 	t.Fatal("file change did not drive a hot reload through the Manager attach loop")
 }
 
+func TestManagerReloadDelegatesToDevServer(t *testing.T) {
+	ds := &fakeAttachDevServer{}
+	m := newAttachManager(t, ds)
+	m.SetExternalDebugURL("http://127.0.0.1:1/")
+
+	if _, err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	defer m.Stop()
+
+	if err := m.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload error: %v", err)
+	}
+	if ds.reloadCount() != 1 {
+		t.Fatalf("reloadCount = %d, want 1", ds.reloadCount())
+	}
+	if err := m.HotRestart(context.Background()); err != nil {
+		t.Fatalf("HotRestart error: %v", err)
+	}
+}
+
+func TestManagerReloadWithoutDevServerErrors(t *testing.T) {
+	m := NewManager("flutter", &config.ProviderConfig{}, "/work")
+	if err := m.Reload(context.Background()); err == nil {
+		t.Fatal("Reload should error when no dev server is running")
+	}
+	if err := m.HotRestart(context.Background()); err == nil {
+		t.Fatal("HotRestart should error when no dev server is running")
+	}
+}
+
 func TestStartAttachStopsReverseTunnel(t *testing.T) {
 	ds := &fakeAttachDevServer{}
 	m := newAttachManager(t, ds)

--- a/internal/hotreload/manager_attach_test.go
+++ b/internal/hotreload/manager_attach_test.go
@@ -2,7 +2,11 @@ package hotreload
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/revyl/cli/internal/config"
 )
@@ -11,7 +15,9 @@ import (
 type fakeAttachDevServer struct {
 	debugURL string
 	started  bool
-	reloads  int
+
+	mu      sync.Mutex
+	reloads int
 }
 
 func (f *fakeAttachDevServer) Start(ctx context.Context) error  { f.started = true; return nil }
@@ -21,8 +27,20 @@ func (f *fakeAttachDevServer) GetDeepLinkURL(string) string     { return "" }
 func (f *fakeAttachDevServer) SetProxyURL(string)               {}
 func (f *fakeAttachDevServer) Name() string                     { return "FakeFlutter" }
 func (f *fakeAttachDevServer) SetDebugURL(u string)             { f.debugURL = u }
-func (f *fakeAttachDevServer) Reload(context.Context) error     { f.reloads++; return nil }
 func (f *fakeAttachDevServer) HotRestart(context.Context) error { return nil }
+
+func (f *fakeAttachDevServer) Reload(context.Context) error {
+	f.mu.Lock()
+	f.reloads++
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeAttachDevServer) reloadCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reloads
+}
 
 // fakeReverseTunnel records the reverse-forward request for tests.
 type fakeReverseTunnel struct {
@@ -107,6 +125,47 @@ func TestStartAttachRequiresDevicePort(t *testing.T) {
 	if _, err := m.Start(context.Background()); err == nil {
 		t.Fatal("Start should error when neither device port nor external debug URL is set")
 	}
+}
+
+func TestStartAttachDrivesReloadOnFileChange(t *testing.T) {
+	// Use a real temp dir so the file watcher can start, and a .dart file so a
+	// change classifies as a hot reload.
+	dir := t.TempDir()
+	libDir := filepath.Join(dir, "lib")
+	if err := os.MkdirAll(libDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mainDart := filepath.Join(libDir, "main.dart")
+	if err := os.WriteFile(mainDart, []byte("void main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write main.dart: %v", err)
+	}
+
+	ds := &fakeAttachDevServer{}
+	RegisterFlutterAttachDevServerFactory(func(workDir string) DevServer { return ds })
+	t.Cleanup(func() { RegisterFlutterAttachDevServerFactory(nil) })
+
+	m := NewManager("flutter", &config.ProviderConfig{}, dir)
+	m.SetDevLoopStyle(DevLoopStyleAttach)
+	m.SetExternalDebugURL("http://127.0.0.1:1/")
+
+	if _, err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	defer m.Stop()
+
+	// Edit the .dart file; the watcher (800ms debounce) -> driver -> Reload().
+	if err := os.WriteFile(mainDart, []byte("void main() {}\n// changed\n"), 0o644); err != nil {
+		t.Fatalf("edit main.dart: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if ds.reloadCount() > 0 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("file change did not drive a hot reload through the Manager attach loop")
 }
 
 func TestStartAttachStopsReverseTunnel(t *testing.T) {

--- a/internal/hotreload/manager_attach_test.go
+++ b/internal/hotreload/manager_attach_test.go
@@ -1,0 +1,126 @@
+package hotreload
+
+import (
+	"context"
+	"testing"
+
+	"github.com/revyl/cli/internal/config"
+)
+
+// fakeAttachDevServer is a DevServer that records attach wiring for tests.
+type fakeAttachDevServer struct {
+	debugURL string
+	started  bool
+	reloads  int
+}
+
+func (f *fakeAttachDevServer) Start(ctx context.Context) error  { f.started = true; return nil }
+func (f *fakeAttachDevServer) Stop() error                      { return nil }
+func (f *fakeAttachDevServer) GetPort() int                     { return 0 }
+func (f *fakeAttachDevServer) GetDeepLinkURL(string) string     { return "" }
+func (f *fakeAttachDevServer) SetProxyURL(string)               {}
+func (f *fakeAttachDevServer) Name() string                     { return "FakeFlutter" }
+func (f *fakeAttachDevServer) SetDebugURL(u string)             { f.debugURL = u }
+func (f *fakeAttachDevServer) Reload(context.Context) error     { f.reloads++; return nil }
+func (f *fakeAttachDevServer) HotRestart(context.Context) error { return nil }
+
+// fakeReverseTunnel records the reverse-forward request for tests.
+type fakeReverseTunnel struct {
+	startedPort int
+	localAddr   string
+	stopped     bool
+}
+
+func (f *fakeReverseTunnel) StartReverse(ctx context.Context, devicePort int) (string, error) {
+	f.startedPort = devicePort
+	f.localAddr = "127.0.0.1:55555"
+	return f.localAddr, nil
+}
+func (f *fakeReverseTunnel) StopReverse() error { f.stopped = true; return nil }
+func (f *fakeReverseTunnel) LocalAddr() string  { return f.localAddr }
+
+func newAttachManager(t *testing.T, ds DevServer) *Manager {
+	t.Helper()
+	RegisterFlutterAttachDevServerFactory(func(workDir string) DevServer { return ds })
+	t.Cleanup(func() { RegisterFlutterAttachDevServerFactory(nil) })
+
+	m := NewManager("flutter", &config.ProviderConfig{}, "/work")
+	m.SetDevLoopStyle(DevLoopStyleAttach)
+	return m
+}
+
+func TestStartAttachUsesReverseTunnel(t *testing.T) {
+	ds := &fakeAttachDevServer{}
+	m := newAttachManager(t, ds)
+	ft := &fakeReverseTunnel{}
+	m.SetReverseTunnelBackendFactory(func() ReverseTunnelBackend { return ft })
+	m.SetDeviceVMServicePort(8181)
+
+	res, err := m.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	defer m.Stop()
+
+	if ft.startedPort != 8181 {
+		t.Fatalf("reverse tunnel started for port %d, want 8181", ft.startedPort)
+	}
+	if ds.debugURL != "http://127.0.0.1:55555/" {
+		t.Fatalf("dev server debug URL = %q, want http://127.0.0.1:55555/", ds.debugURL)
+	}
+	if !ds.started {
+		t.Fatal("attach dev server was not started")
+	}
+	if res.Transport != "reverse-relay" {
+		t.Fatalf("transport = %q, want reverse-relay", res.Transport)
+	}
+}
+
+func TestStartAttachExternalDebugURLSkipsReverseTunnel(t *testing.T) {
+	ds := &fakeAttachDevServer{}
+	m := newAttachManager(t, ds)
+	ft := &fakeReverseTunnel{}
+	m.SetReverseTunnelBackendFactory(func() ReverseTunnelBackend { return ft })
+	m.SetExternalDebugURL("http://127.0.0.1:12345/abc=/")
+
+	res, err := m.Start(context.Background())
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	defer m.Stop()
+
+	if ft.startedPort != 0 {
+		t.Fatal("reverse tunnel should not be used when an external debug URL is set")
+	}
+	if ds.debugURL != "http://127.0.0.1:12345/abc=/" {
+		t.Fatalf("dev server debug URL = %q, want the external URL", ds.debugURL)
+	}
+	if res.Transport != "external-attach" {
+		t.Fatalf("transport = %q, want external-attach", res.Transport)
+	}
+}
+
+func TestStartAttachRequiresDevicePort(t *testing.T) {
+	ds := &fakeAttachDevServer{}
+	m := newAttachManager(t, ds)
+	// No device port and no external debug URL -> error.
+	if _, err := m.Start(context.Background()); err == nil {
+		t.Fatal("Start should error when neither device port nor external debug URL is set")
+	}
+}
+
+func TestStartAttachStopsReverseTunnel(t *testing.T) {
+	ds := &fakeAttachDevServer{}
+	m := newAttachManager(t, ds)
+	ft := &fakeReverseTunnel{}
+	m.SetReverseTunnelBackendFactory(func() ReverseTunnelBackend { return ft })
+	m.SetDeviceVMServicePort(9000)
+
+	if _, err := m.Start(context.Background()); err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	m.Stop()
+	if !ft.stopped {
+		t.Fatal("reverse tunnel was not stopped on Manager.Stop")
+	}
+}

--- a/internal/hotreload/provider.go
+++ b/internal/hotreload/provider.go
@@ -90,6 +90,39 @@ type Provider interface {
 	IsSupported() bool
 }
 
+// Dev-loop styles describe how a provider delivers code changes to a device.
+const (
+	// DevLoopStyleMetro is the JS bundler model: the device pulls a fresh
+	// bundle from a local dev server through a forward relay.
+	DevLoopStyleMetro = "metro"
+
+	// DevLoopStyleAttach is the in-place reload model: the host attaches to the
+	// running app's debug port (via a reverse relay) and pushes code (Flutter).
+	DevLoopStyleAttach = "attach"
+
+	// DevLoopStyleRebuild is the rebuild-on-change model: every change produces
+	// a new binary that is re-uploaded and reinstalled (native iOS/Android).
+	DevLoopStyleRebuild = "rebuild"
+)
+
+// ProviderDevLoopStyler is an optional interface a Provider may implement to
+// declare how its dev loop delivers changes. Providers that do not implement it
+// are treated as DevLoopStyleRebuild by ProviderDevLoopStyle.
+type ProviderDevLoopStyler interface {
+	DevLoopStyle() string
+}
+
+// ProviderDevLoopStyle returns the dev-loop style for a provider, defaulting to
+// DevLoopStyleRebuild when the provider does not declare one.
+func ProviderDevLoopStyle(p Provider) string {
+	if styler, ok := p.(ProviderDevLoopStyler); ok {
+		if style := styler.DevLoopStyle(); style != "" {
+			return style
+		}
+	}
+	return DevLoopStyleRebuild
+}
+
 // DetectionResult contains the result of provider detection.
 type DetectionResult struct {
 	// Provider is the provider name that detected this project.

--- a/internal/hotreload/providers/flutter_devserver.go
+++ b/internal/hotreload/providers/flutter_devserver.go
@@ -38,6 +38,7 @@ var (
 	_ hotreload.DevServer              = (*FlutterAttachDevServer)(nil)
 	_ hotreload.Reloadable             = (*FlutterAttachDevServer)(nil)
 	_ hotreload.DevServerOutputEmitter = (*FlutterAttachDevServer)(nil)
+	_ hotreload.DebugURLConfigurable   = (*FlutterAttachDevServer)(nil)
 )
 
 // NewFlutterAttachDevServer creates a Flutter attach dev server. debugURL is

--- a/internal/hotreload/providers/flutter_devserver.go
+++ b/internal/hotreload/providers/flutter_devserver.go
@@ -1,0 +1,177 @@
+package providers
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/revyl/cli/internal/hotreload"
+)
+
+// FlutterAttachDevServer drives `flutter attach` against a running debug build
+// on a cloud device. The app exposes its Dart VM Service on the device; a
+// ReverseTunnelBackend bridges that port to a local address (debugURL), and
+// this dev server attaches to it and issues hot reload / hot restart in
+// response to file changes.
+//
+// Unlike the Metro dev server, this one actively drives the running app rather
+// than passively serving a bundle, so it implements hotreload.Reloadable.
+type FlutterAttachDevServer struct {
+	workDir  string
+	debugURL string
+
+	// commandFn is injectable for tests. Defaults to exec.CommandContext.
+	commandFn func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+	mu       sync.Mutex
+	cmd      *exec.Cmd
+	stdin    io.WriteCloser
+	onOutput hotreload.DevServerOutputCallback
+}
+
+// Compile-time assertions that the dev server satisfies the expected contracts.
+var (
+	_ hotreload.DevServer              = (*FlutterAttachDevServer)(nil)
+	_ hotreload.Reloadable             = (*FlutterAttachDevServer)(nil)
+	_ hotreload.DevServerOutputEmitter = (*FlutterAttachDevServer)(nil)
+)
+
+// NewFlutterAttachDevServer creates a Flutter attach dev server. debugURL is
+// the local address produced by the reverse tunnel (e.g.
+// "http://127.0.0.1:54321/"); it may be set later via SetDebugURL.
+func NewFlutterAttachDevServer(workDir, debugURL string) *FlutterAttachDevServer {
+	return &FlutterAttachDevServer{
+		workDir:   workDir,
+		debugURL:  strings.TrimSpace(debugURL),
+		commandFn: exec.CommandContext,
+	}
+}
+
+// SetDebugURL sets the VM Service URL to attach to. Must be called before Start.
+func (f *FlutterAttachDevServer) SetDebugURL(debugURL string) {
+	f.mu.Lock()
+	f.debugURL = strings.TrimSpace(debugURL)
+	f.mu.Unlock()
+}
+
+// SetOutputCallback registers a callback for process output lines.
+func (f *FlutterAttachDevServer) SetOutputCallback(cb hotreload.DevServerOutputCallback) {
+	f.mu.Lock()
+	f.onOutput = cb
+	f.mu.Unlock()
+}
+
+// attachArgs builds the `flutter attach` argument list. Exposed for testing.
+func (f *FlutterAttachDevServer) attachArgs() []string {
+	return []string{"attach", "--no-version-check", "--debug-url", f.debugURL}
+}
+
+// Start launches `flutter attach` and begins streaming its output.
+func (f *FlutterAttachDevServer) Start(ctx context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.debugURL == "" {
+		return fmt.Errorf("flutter attach requires a VM Service debug URL (reverse tunnel not established)")
+	}
+	if f.cmd != nil {
+		return fmt.Errorf("flutter attach is already running")
+	}
+
+	cmd := f.commandFn(ctx, "flutter", f.attachArgs()...)
+	cmd.Dir = f.workDir
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to open flutter attach stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to open flutter attach stdout: %w", err)
+	}
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start flutter attach: %w", err)
+	}
+
+	f.cmd = cmd
+	f.stdin = stdin
+	go f.streamOutput(stdout)
+	return nil
+}
+
+func (f *FlutterAttachDevServer) streamOutput(stdout io.Reader) {
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		f.mu.Lock()
+		cb := f.onOutput
+		f.mu.Unlock()
+		if cb != nil {
+			cb(hotreload.DevServerOutput{Stream: hotreload.DevServerOutputStdout, Line: line})
+		}
+	}
+}
+
+// Reload issues a Flutter hot reload ("r").
+func (f *FlutterAttachDevServer) Reload(ctx context.Context) error {
+	return f.sendKey("r")
+}
+
+// HotRestart issues a Flutter hot restart ("R").
+func (f *FlutterAttachDevServer) HotRestart(ctx context.Context) error {
+	return f.sendKey("R")
+}
+
+func (f *FlutterAttachDevServer) sendKey(key string) error {
+	f.mu.Lock()
+	stdin := f.stdin
+	f.mu.Unlock()
+	if stdin == nil {
+		return fmt.Errorf("flutter attach is not running")
+	}
+	if _, err := io.WriteString(stdin, key+"\n"); err != nil {
+		return fmt.Errorf("failed to send %q to flutter attach: %w", key, err)
+	}
+	return nil
+}
+
+// Stop terminates the flutter attach process.
+func (f *FlutterAttachDevServer) Stop() error {
+	f.mu.Lock()
+	cmd := f.cmd
+	stdin := f.stdin
+	f.cmd = nil
+	f.stdin = nil
+	f.mu.Unlock()
+
+	if cmd == nil {
+		return nil
+	}
+	if stdin != nil {
+		_, _ = io.WriteString(stdin, "q\n")
+		_ = stdin.Close()
+	}
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+	_ = cmd.Wait()
+	return nil
+}
+
+// GetPort returns 0; Flutter attach is not an HTTP server the device pulls from.
+func (f *FlutterAttachDevServer) GetPort() int { return 0 }
+
+// GetDeepLinkURL is a no-op; attach uses a VM Service URL, not a deep link.
+func (f *FlutterAttachDevServer) GetDeepLinkURL(tunnelURL string) string { return "" }
+
+// SetProxyURL is a no-op; there is no Metro bundle URL to rewrite.
+func (f *FlutterAttachDevServer) SetProxyURL(tunnelURL string) {}
+
+// Name returns the human-readable provider name.
+func (f *FlutterAttachDevServer) Name() string { return "Flutter" }

--- a/internal/hotreload/providers/flutter_devserver.go
+++ b/internal/hotreload/providers/flutter_devserver.go
@@ -23,6 +23,7 @@ import (
 type FlutterAttachDevServer struct {
 	workDir  string
 	debugURL string
+	deviceID string
 
 	// commandFn is injectable for tests. Defaults to exec.CommandContext.
 	commandFn func(ctx context.Context, name string, args ...string) *exec.Cmd
@@ -59,6 +60,14 @@ func (f *FlutterAttachDevServer) SetDebugURL(debugURL string) {
 	f.mu.Unlock()
 }
 
+// SetDeviceID sets the target device for `flutter attach -d <id>`. Required when
+// more than one Flutter device is connected. Must be called before Start.
+func (f *FlutterAttachDevServer) SetDeviceID(deviceID string) {
+	f.mu.Lock()
+	f.deviceID = strings.TrimSpace(deviceID)
+	f.mu.Unlock()
+}
+
 // SetOutputCallback registers a callback for process output lines.
 func (f *FlutterAttachDevServer) SetOutputCallback(cb hotreload.DevServerOutputCallback) {
 	f.mu.Lock()
@@ -68,7 +77,12 @@ func (f *FlutterAttachDevServer) SetOutputCallback(cb hotreload.DevServerOutputC
 
 // attachArgs builds the `flutter attach` argument list. Exposed for testing.
 func (f *FlutterAttachDevServer) attachArgs() []string {
-	return []string{"attach", "--no-version-check", "--debug-url", f.debugURL}
+	args := []string{"attach", "--no-version-check"}
+	if f.deviceID != "" {
+		args = append(args, "-d", f.deviceID)
+	}
+	args = append(args, "--debug-url", f.debugURL)
+	return args
 }
 
 // Start launches `flutter attach` and begins streaming its output.

--- a/internal/hotreload/providers/flutter_devserver.go
+++ b/internal/hotreload/providers/flutter_devserver.go
@@ -40,6 +40,7 @@ var (
 	_ hotreload.Reloadable             = (*FlutterAttachDevServer)(nil)
 	_ hotreload.DevServerOutputEmitter = (*FlutterAttachDevServer)(nil)
 	_ hotreload.DebugURLConfigurable   = (*FlutterAttachDevServer)(nil)
+	_ hotreload.DeviceIDConfigurable   = (*FlutterAttachDevServer)(nil)
 )
 
 // NewFlutterAttachDevServer creates a Flutter attach dev server. debugURL is

--- a/internal/hotreload/providers/flutter_devserver_poc_test.go
+++ b/internal/hotreload/providers/flutter_devserver_poc_test.go
@@ -1,0 +1,137 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/revyl/cli/internal/hotreload"
+)
+
+// TestFlutterAttachPoC is a manual, env-gated end-to-end check. It attaches to
+// an already-running Flutter app via our FlutterAttachDevServer and verifies a
+// hot reload round-trips. It is skipped unless APP_DIR and VM_SERVICE_URL are
+// set, so it never runs in CI.
+//
+// Usage:
+//
+//	# 1. In one shell: flutter run -d <device> (note the VM Service URL it prints)
+//	# 2. In another:
+//	APP_DIR=/tmp/revyl_poc_app \
+//	VM_SERVICE_URL=http://127.0.0.1:PORT/TOKEN=/ \
+//	  go test ./internal/hotreload/providers/ -run TestFlutterAttachPoC -v -timeout 360s
+func TestFlutterAttachPoC(t *testing.T) {
+	appDir := os.Getenv("APP_DIR")
+	vmURL := os.Getenv("VM_SERVICE_URL")
+	if appDir == "" || vmURL == "" {
+		t.Skip("set APP_DIR and VM_SERVICE_URL to run the Flutter attach PoC")
+	}
+
+	var mu sync.Mutex
+	var lines []string
+	srv := NewFlutterAttachDevServer(appDir, vmURL)
+	if deviceID := os.Getenv("DEVICE_ID"); deviceID != "" {
+		srv.SetDeviceID(deviceID)
+	}
+	srv.SetOutputCallback(func(o hotreload.DevServerOutput) {
+		mu.Lock()
+		lines = append(lines, o.Line)
+		mu.Unlock()
+		t.Logf("[attach] %s", o.Line)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if err := srv.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer srv.Stop()
+
+	waitForLine(t, &mu, &lines, []string{"key commands", "To hot reload", "Flutter run"}, 120*time.Second)
+
+	if err := srv.Reload(ctx); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	waitForLine(t, &mu, &lines, []string{"Reloaded", "hot reload"}, 90*time.Second)
+	t.Log("phase 1: direct hot reload confirmed through FlutterAttachDevServer")
+
+	// Phase 2: full chain — file change -> FileWatcher -> ReloadDriver -> Reload.
+	driver, watcher, err := hotreload.NewFlutterReloadDriver(appDir, srv)
+	if err != nil {
+		t.Fatalf("NewFlutterReloadDriver: %v", err)
+	}
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("watcher.Start: %v", err)
+	}
+	defer watcher.Stop()
+	go func() { _ = driver.Run(ctx) }()
+
+	mu.Lock()
+	mark := len(lines)
+	mu.Unlock()
+
+	editMainDart(t, appDir)
+
+	waitForLineAfter(t, &mu, &lines, mark, []string{"Reloaded", "Performing hot reload"}, 90*time.Second)
+	t.Log("phase 2: file change -> hot reload confirmed through ReloadDriver")
+}
+
+// editMainDart appends a harmless top-level comment to lib/main.dart to trigger
+// a file-change event without breaking compilation.
+func editMainDart(t *testing.T, appDir string) {
+	t.Helper()
+	path := filepath.Join(appDir, "lib", "main.dart")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open main.dart: %v", err)
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintf(f, "\n// revyl-poc %d\n", time.Now().UnixNano()); err != nil {
+		t.Fatalf("write main.dart: %v", err)
+	}
+}
+
+func waitForLineAfter(t *testing.T, mu *sync.Mutex, lines *[]string, after int, subs []string, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		for i := after; i < len(*lines); i++ {
+			for _, s := range subs {
+				if strings.Contains((*lines)[i], s) {
+					mu.Unlock()
+					return
+				}
+			}
+		}
+		mu.Unlock()
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("did not see any of %v after index %d within %s", subs, after, d)
+}
+
+func waitForLine(t *testing.T, mu *sync.Mutex, lines *[]string, subs []string, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		for _, l := range *lines {
+			for _, s := range subs {
+				if strings.Contains(l, s) {
+					mu.Unlock()
+					return
+				}
+			}
+		}
+		mu.Unlock()
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("did not see any of %v within %s", subs, d)
+}

--- a/internal/hotreload/providers/flutter_devserver_test.go
+++ b/internal/hotreload/providers/flutter_devserver_test.go
@@ -1,0 +1,63 @@
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestFlutterAttachArgs(t *testing.T) {
+	srv := NewFlutterAttachDevServer("/work", "http://127.0.0.1:54321/")
+	args := srv.attachArgs()
+	want := []string{"attach", "--no-version-check", "--debug-url", "http://127.0.0.1:54321/"}
+	if len(args) != len(want) {
+		t.Fatalf("attachArgs length = %d, want %d (%v)", len(args), len(want), args)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("attachArgs[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
+func TestFlutterAttachStartRequiresDebugURL(t *testing.T) {
+	srv := NewFlutterAttachDevServer("/work", "")
+	err := srv.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start without a debug URL should error")
+	}
+	if !strings.Contains(err.Error(), "debug URL") {
+		t.Fatalf("error should mention the missing debug URL, got %v", err)
+	}
+}
+
+func TestFlutterAttachReloadRequiresRunning(t *testing.T) {
+	srv := NewFlutterAttachDevServer("/work", "http://127.0.0.1:1/")
+	if err := srv.Reload(context.Background()); err == nil {
+		t.Fatal("Reload before Start should error")
+	}
+	if err := srv.HotRestart(context.Background()); err == nil {
+		t.Fatal("HotRestart before Start should error")
+	}
+}
+
+func TestFlutterAttachSetDebugURL(t *testing.T) {
+	srv := NewFlutterAttachDevServer("/work", "")
+	srv.SetDebugURL("  http://127.0.0.1:9999/  ")
+	if got := srv.attachArgs()[3]; got != "http://127.0.0.1:9999/" {
+		t.Fatalf("SetDebugURL should trim and store, got %q", got)
+	}
+}
+
+func TestFlutterAttachStaticContracts(t *testing.T) {
+	srv := NewFlutterAttachDevServer("/work", "http://127.0.0.1:1/")
+	if srv.Name() != "Flutter" {
+		t.Fatalf("Name() = %q, want Flutter", srv.Name())
+	}
+	if srv.GetPort() != 0 {
+		t.Fatalf("GetPort() = %d, want 0", srv.GetPort())
+	}
+	if srv.GetDeepLinkURL("x") != "" {
+		t.Fatal("GetDeepLinkURL should be a no-op")
+	}
+}

--- a/internal/hotreload/providers/flutter_devserver_test.go
+++ b/internal/hotreload/providers/flutter_devserver_test.go
@@ -20,6 +20,21 @@ func TestFlutterAttachArgs(t *testing.T) {
 	}
 }
 
+func TestFlutterAttachArgsWithDeviceID(t *testing.T) {
+	srv := NewFlutterAttachDevServer("/work", "http://127.0.0.1:54321/")
+	srv.SetDeviceID("sim-123")
+	args := srv.attachArgs()
+	want := []string{"attach", "--no-version-check", "-d", "sim-123", "--debug-url", "http://127.0.0.1:54321/"}
+	if len(args) != len(want) {
+		t.Fatalf("attachArgs = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("attachArgs[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}
+
 func TestFlutterAttachStartRequiresDebugURL(t *testing.T) {
 	srv := NewFlutterAttachDevServer("/work", "")
 	err := srv.Start(context.Background())

--- a/internal/hotreload/providers/flutter_provider.go
+++ b/internal/hotreload/providers/flutter_provider.go
@@ -169,6 +169,9 @@ func (p *FlutterProvider) CreateDevServer(cfg *config.ProviderConfig, workDir st
 
 // DevLoopStyle reports that Flutter uses the attach-based reload model, driving
 // hot reload over a reverse relay to the device's Dart VM Service.
+//
+// Returns:
+//   - string: hotreload.DevLoopStyleAttach
 func (p *FlutterProvider) DevLoopStyle() string {
 	return hotreload.DevLoopStyleAttach
 }

--- a/internal/hotreload/providers/flutter_provider.go
+++ b/internal/hotreload/providers/flutter_provider.go
@@ -149,26 +149,35 @@ func (p *FlutterProvider) GetDefaultConfig(info *hotreload.ProjectInfo) *config.
 	return &config.ProviderConfig{}
 }
 
-// CreateDevServer returns an error because Flutter uses a rebuild-based dev loop
-// rather than a live dev server. The rebuild loop is handled by runDevRebuildOnly
-// in dev.go with automatic file watching.
+// CreateDevServer returns a Flutter attach dev server. The VM Service debug URL
+// is supplied at runtime via SetDebugURL once the reverse tunnel to the device
+// is established (see the attach orchestration in the hot-reload Manager).
 //
 // Parameters:
-//   - cfg: Provider configuration (unused)
-//   - workDir: Working directory (unused)
+//   - cfg: Provider configuration (currently unused)
+//   - workDir: Working directory for the Flutter project
 //
 // Returns:
-//   - hotreload.DevServer: nil
-//   - error: Explanation that Flutter uses rebuild-based dev loop
+//   - hotreload.DevServer: a FlutterAttachDevServer (debug URL set later)
+//   - error: nil
 func (p *FlutterProvider) CreateDevServer(cfg *config.ProviderConfig, workDir string) (hotreload.DevServer, error) {
-	return nil, fmt.Errorf("Flutter uses an auto-rebuild dev loop — no dev server needed")
+	return NewFlutterAttachDevServer(workDir, ""), nil
 }
 
-// IsSupported returns false because Flutter does not use a hot-reload dev server.
-// It routes through the rebuild-only path in revyl dev with file watching.
+// DevLoopStyle reports that Flutter uses the attach-based reload model, driving
+// hot reload over a reverse relay to the device's Dart VM Service.
+func (p *FlutterProvider) DevLoopStyle() string {
+	return hotreload.DevLoopStyleAttach
+}
+
+// IsSupported reports whether the attach-based Flutter hot-reload path is fully
+// wired end to end. It returns false until backend reverse-relay support and
+// the Manager attach orchestration land; until then revyl dev keeps routing
+// Flutter through the rebuild-only loop. See
+// docs/developer_loop/flutter-hot-reload-design.md.
 //
 // Returns:
-//   - bool: false
+//   - bool: false (gated)
 func (p *FlutterProvider) IsSupported() bool {
 	return false
 }

--- a/internal/hotreload/providers/flutter_provider.go
+++ b/internal/hotreload/providers/flutter_provider.go
@@ -12,6 +12,9 @@ import (
 
 func init() {
 	hotreload.RegisterProvider(&FlutterProvider{})
+	hotreload.RegisterFlutterAttachDevServerFactory(func(workDir string) hotreload.DevServer {
+		return NewFlutterAttachDevServer(workDir, "")
+	})
 }
 
 // FlutterProvider implements the Provider interface for Flutter projects.

--- a/internal/hotreload/reload_driver.go
+++ b/internal/hotreload/reload_driver.go
@@ -1,0 +1,175 @@
+package hotreload
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ReloadAction is the response a set of changed files requires from an
+// attach-based dev loop.
+type ReloadAction int
+
+const (
+	// ReloadActionNone means the change does not require any action.
+	ReloadActionNone ReloadAction = iota
+
+	// ReloadActionReload means a hot reload is sufficient (most .dart edits).
+	ReloadActionReload
+
+	// ReloadActionRestart means a hot restart is required (state is lost).
+	ReloadActionRestart
+
+	// ReloadActionRebuild means a full rebuild + reinstall is required
+	// (pubspec / native changes); the attach session cannot apply it.
+	ReloadActionRebuild
+)
+
+// String returns a human-readable label for the action.
+func (a ReloadAction) String() string {
+	switch a {
+	case ReloadActionReload:
+		return "reload"
+	case ReloadActionRestart:
+		return "restart"
+	case ReloadActionRebuild:
+		return "rebuild"
+	default:
+		return "none"
+	}
+}
+
+// ClassifyFlutterChange decides what a set of changed files requires for a
+// Flutter attach dev loop.
+//
+//   - pubspec.yaml or native directories (ios/android/macos/windows/linux) ->
+//     rebuild, because the attach session cannot apply native/dependency changes.
+//   - any .dart file -> hot reload.
+//   - otherwise -> none.
+//
+// Hot restart is not auto-classified from filenames (the cases that need it —
+// changes to main()/global state — are not reliably detectable from a path); it
+// is offered as a manual action instead.
+func ClassifyFlutterChange(files []string) ReloadAction {
+	action := ReloadActionNone
+	for _, f := range files {
+		lower := strings.ToLower(filepath.ToSlash(f))
+		base := strings.ToLower(filepath.Base(f))
+
+		if base == "pubspec.yaml" || base == "pubspec.lock" {
+			return ReloadActionRebuild
+		}
+		if isNativeDirPath(lower) {
+			return ReloadActionRebuild
+		}
+		if strings.HasSuffix(base, ".dart") {
+			action = ReloadActionReload
+		}
+	}
+	return action
+}
+
+func isNativeDirPath(slashPath string) bool {
+	for _, dir := range []string{"ios/", "android/", "macos/", "windows/", "linux/"} {
+		if strings.HasPrefix(slashPath, dir) || strings.Contains(slashPath, "/"+dir) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReloadDriver consumes file-change events and drives an attach-based dev server
+// (Reloadable) accordingly. It is decoupled from FileWatcher so it can be unit
+// tested with a plain channel; use NewFlutterReloadDriver to wire a real watcher.
+type ReloadDriver struct {
+	changes   <-chan FileChangeEvent
+	target    Reloadable
+	classify  func([]string) ReloadAction
+	onRebuild func(files []string)
+	onLog     func(string)
+}
+
+// NewReloadDriver creates a driver that reads from changes and drives target.
+// The classifier defaults to ClassifyFlutterChange.
+func NewReloadDriver(changes <-chan FileChangeEvent, target Reloadable) *ReloadDriver {
+	return &ReloadDriver{
+		changes:  changes,
+		target:   target,
+		classify: ClassifyFlutterChange,
+	}
+}
+
+// SetClassifier overrides the change classifier.
+func (d *ReloadDriver) SetClassifier(fn func([]string) ReloadAction) {
+	if fn != nil {
+		d.classify = fn
+	}
+}
+
+// SetRebuildHandler registers a callback invoked when a change requires a full
+// rebuild (the attach session cannot apply it). If unset, rebuild-class changes
+// are logged and skipped.
+func (d *ReloadDriver) SetRebuildHandler(fn func(files []string)) {
+	d.onRebuild = fn
+}
+
+// SetLogCallback registers a log callback.
+func (d *ReloadDriver) SetLogCallback(fn func(string)) {
+	d.onLog = fn
+}
+
+func (d *ReloadDriver) log(format string, args ...interface{}) {
+	if d.onLog != nil {
+		d.onLog(fmt.Sprintf(format, args...))
+	}
+}
+
+// Run consumes change events until ctx is cancelled or the changes channel is
+// closed. Events are handled one at a time, in order.
+func (d *ReloadDriver) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-d.changes:
+			if !ok {
+				return nil
+			}
+			d.handle(ctx, ev)
+		}
+	}
+}
+
+func (d *ReloadDriver) handle(ctx context.Context, ev FileChangeEvent) {
+	switch d.classify(ev.Files) {
+	case ReloadActionReload:
+		d.log("Hot reloading (%d file(s) changed)...", len(ev.Files))
+		if err := d.target.Reload(ctx); err != nil {
+			d.log("Hot reload failed: %v", err)
+		}
+	case ReloadActionRestart:
+		d.log("Hot restarting...")
+		if err := d.target.HotRestart(ctx); err != nil {
+			d.log("Hot restart failed: %v", err)
+		}
+	case ReloadActionRebuild:
+		if d.onRebuild != nil {
+			d.log("Change requires a rebuild; delegating...")
+			d.onRebuild(ev.Files)
+		} else {
+			d.log("Change requires a rebuild (pubspec/native); not applied by hot reload.")
+		}
+	}
+}
+
+// NewFlutterReloadDriver builds a ReloadDriver wired to a Flutter file watcher
+// rooted at rootDir. The caller is responsible for starting the returned watcher
+// (watcher.Start) before calling driver.Run, and stopping it afterward.
+func NewFlutterReloadDriver(rootDir string, target Reloadable) (*ReloadDriver, *FileWatcher, error) {
+	watcher, err := NewFileWatcher(rootDir, FlutterWatchConfig())
+	if err != nil {
+		return nil, nil, err
+	}
+	return NewReloadDriver(watcher.Changes(), target), watcher, nil
+}

--- a/internal/hotreload/reload_driver_test.go
+++ b/internal/hotreload/reload_driver_test.go
@@ -1,0 +1,179 @@
+package hotreload
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestClassifyFlutterChange(t *testing.T) {
+	cases := []struct {
+		name  string
+		files []string
+		want  ReloadAction
+	}{
+		{"dart edit", []string{"lib/main.dart"}, ReloadActionReload},
+		{"nested dart", []string{"lib/widgets/button.dart"}, ReloadActionReload},
+		{"pubspec", []string{"pubspec.yaml"}, ReloadActionRebuild},
+		{"pubspec lock", []string{"pubspec.lock"}, ReloadActionRebuild},
+		{"ios native", []string{"ios/Runner/AppDelegate.swift"}, ReloadActionRebuild},
+		{"android native", []string{"android/app/build.gradle"}, ReloadActionRebuild},
+		{"dart wins over none", []string{"README.md", "lib/main.dart"}, ReloadActionReload},
+		{"rebuild wins over dart", []string{"lib/main.dart", "pubspec.yaml"}, ReloadActionRebuild},
+		{"unrelated", []string{"README.md"}, ReloadActionNone},
+		{"empty", nil, ReloadActionNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyFlutterChange(tc.files); got != tc.want {
+				t.Fatalf("ClassifyFlutterChange(%v) = %v, want %v", tc.files, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeReloadTarget records reload/restart calls for the driver tests.
+type fakeReloadTarget struct {
+	mu        sync.Mutex
+	reloads   int
+	restarts  int
+	reloadErr error
+}
+
+func (f *fakeReloadTarget) Reload(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reloads++
+	return f.reloadErr
+}
+
+func (f *fakeReloadTarget) HotRestart(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.restarts++
+	return nil
+}
+
+func (f *fakeReloadTarget) reloadCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reloads
+}
+
+func TestReloadDriverTriggersReloadOnDartChange(t *testing.T) {
+	changes := make(chan FileChangeEvent, 1)
+	target := &fakeReloadTarget{}
+	driver := NewReloadDriver(changes, target)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() { _ = driver.Run(ctx); close(done) }()
+
+	changes <- FileChangeEvent{Files: []string{"lib/main.dart"}, Timestamp: time.Now()}
+
+	waitFor(t, func() bool { return target.reloadCount() == 1 }, "reload not triggered")
+	cancel()
+	<-done
+}
+
+func TestReloadDriverDelegatesRebuild(t *testing.T) {
+	changes := make(chan FileChangeEvent, 1)
+	target := &fakeReloadTarget{}
+	driver := NewReloadDriver(changes, target)
+
+	var rebuiltMu sync.Mutex
+	rebuilt := 0
+	driver.SetRebuildHandler(func(files []string) {
+		rebuiltMu.Lock()
+		rebuilt++
+		rebuiltMu.Unlock()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _ = driver.Run(ctx); close(done) }()
+
+	changes <- FileChangeEvent{Files: []string{"pubspec.yaml"}, Timestamp: time.Now()}
+
+	waitFor(t, func() bool {
+		rebuiltMu.Lock()
+		defer rebuiltMu.Unlock()
+		return rebuilt == 1
+	}, "rebuild handler not invoked")
+
+	if target.reloadCount() != 0 {
+		t.Fatal("rebuild-class change must not trigger a hot reload")
+	}
+	cancel()
+	<-done
+}
+
+func TestReloadDriverStopsWhenChannelClosed(t *testing.T) {
+	changes := make(chan FileChangeEvent)
+	driver := NewReloadDriver(changes, &fakeReloadTarget{})
+
+	done := make(chan error, 1)
+	go func() { done <- driver.Run(context.Background()) }()
+
+	close(changes)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned %v, want nil on channel close", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after channel close")
+	}
+}
+
+func TestReloadDriverLogsReloadError(t *testing.T) {
+	changes := make(chan FileChangeEvent, 1)
+	target := &fakeReloadTarget{reloadErr: errors.New("boom")}
+	driver := NewReloadDriver(changes, target)
+
+	var logged []string
+	var logMu sync.Mutex
+	driver.SetLogCallback(func(s string) {
+		logMu.Lock()
+		logged = append(logged, s)
+		logMu.Unlock()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { _ = driver.Run(ctx); close(done) }()
+
+	changes <- FileChangeEvent{Files: []string{"lib/main.dart"}, Timestamp: time.Now()}
+
+	waitFor(t, func() bool {
+		logMu.Lock()
+		defer logMu.Unlock()
+		for _, l := range logged {
+			if strings.Contains(l, "failed") {
+				return true
+			}
+		}
+		return false
+	}, "reload error was not logged")
+	cancel()
+	<-done
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}

--- a/internal/hotreload/reverse_relay.go
+++ b/internal/hotreload/reverse_relay.go
@@ -1,0 +1,339 @@
+package hotreload
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+
+	"github.com/revyl/cli/internal/api"
+)
+
+// Envelope kinds for the reverse (laptop -> device) data plane. These mirror
+// the forward-mode kinds handled in relay.go, but flow the other direction:
+// the CLI opens streams and the backend dials a port on the device.
+const (
+	reverseKindDialStart = "device.dial.start"
+	reverseKindData      = "device.dial.data"
+	reverseKindClose     = "device.dial.close"
+	reverseKindError     = "stream.error"
+)
+
+// ReverseRelayTunnelBackend exposes a port on the cloud device (the Dart VM
+// Service) as a local TCP address on the developer's machine, by proxying
+// raw bytes over a backend-owned relay websocket.
+//
+// It is the mirror image of RelayTunnelBackend: instead of accepting
+// device-initiated streams and dialing 127.0.0.1 on the laptop, it accepts
+// laptop-initiated connections on a local listener and asks the backend to
+// dial the device. The transport is protocol-agnostic (raw TCP), so it carries
+// the VM Service's HTTP upgrade and websocket frames transparently — which is
+// exactly what `flutter attach --debug-url` needs.
+//
+// NOTE: This requires backend support for reverse-mode relay sessions. See
+// docs/developer_loop/flutter-hot-reload-design.md for the contract. Until the
+// backend ships, StartReverse will fail at session creation; the type is wired
+// and tested against the envelope protocol in isolation.
+type ReverseRelayTunnelBackend struct {
+	client   *api.Client
+	provider string
+	platform string
+
+	mu         sync.Mutex
+	session    *api.HotReloadRelaySession
+	conn       *websocket.Conn
+	listener   net.Listener
+	localAddr  string
+	devicePort int
+	runCtx     context.Context
+	cancel     context.CancelFunc
+	stopped    bool
+	onLog      func(string)
+
+	writeMu sync.Mutex
+
+	streamMu sync.Mutex
+	streams  map[string]net.Conn
+}
+
+// NewReverseRelayTunnelBackend creates a reverse relay transport.
+func NewReverseRelayTunnelBackend(client *api.Client, provider, platform string) *ReverseRelayTunnelBackend {
+	return &ReverseRelayTunnelBackend{
+		client:   client,
+		provider: strings.TrimSpace(provider),
+		platform: strings.TrimSpace(platform),
+		streams:  make(map[string]net.Conn),
+	}
+}
+
+// SetLogCallback registers a log callback.
+func (r *ReverseRelayTunnelBackend) SetLogCallback(cb func(string)) {
+	r.mu.Lock()
+	r.onLog = cb
+	r.mu.Unlock()
+}
+
+func (r *ReverseRelayTunnelBackend) log(format string, args ...interface{}) {
+	r.mu.Lock()
+	cb := r.onLog
+	r.mu.Unlock()
+	if cb != nil {
+		cb(fmt.Sprintf(format, args...))
+	}
+}
+
+// LocalAddr returns the current local proxy address, or "" if not running.
+func (r *ReverseRelayTunnelBackend) LocalAddr() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.localAddr
+}
+
+// StartReverse provisions a reverse relay session, connects the CLI websocket,
+// and opens a local TCP listener that proxies to devicePort on the device.
+func (r *ReverseRelayTunnelBackend) StartReverse(ctx context.Context, devicePort int) (string, error) {
+	if r.client == nil {
+		return "", fmt.Errorf("reverse relay requires an authenticated API client")
+	}
+	if devicePort <= 0 {
+		return "", fmt.Errorf("reverse relay requires a positive device port, got %d", devicePort)
+	}
+
+	session, err := r.client.CreateHotReloadRelay(ctx, api.HotReloadRelayCreateParams{
+		Provider:   r.provider,
+		Platform:   r.platform,
+		Mode:       api.HotReloadRelayModeReverse,
+		DevicePort: devicePort,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create reverse relay session: %w", err)
+	}
+
+	wsURL, err := session.ConnectWebSocketURL()
+	if err != nil {
+		return "", err
+	}
+	headers := http.Header{"User-Agent": []string{"revyl-cli-relay"}}
+	if authHeader := session.ConnectAuthHeader(); authHeader != "" {
+		headers.Set("Authorization", authHeader)
+	}
+	dialer := websocket.Dialer{HandshakeTimeout: 30 * time.Second}
+	conn, _, err := dialer.DialContext(ctx, wsURL, headers)
+	if err != nil {
+		_ = r.client.RevokeHotReloadRelay(context.Background(), session.RelayID)
+		return "", fmt.Errorf("failed to connect reverse relay websocket: %w", err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		_ = conn.Close()
+		_ = r.client.RevokeHotReloadRelay(context.Background(), session.RelayID)
+		return "", fmt.Errorf("failed to open local reverse listener: %w", err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+
+	r.mu.Lock()
+	r.session = session
+	r.conn = conn
+	r.listener = listener
+	r.localAddr = listener.Addr().String()
+	r.devicePort = devicePort
+	r.runCtx = runCtx
+	r.cancel = cancel
+	r.stopped = false
+	localAddr := r.localAddr
+	r.mu.Unlock()
+
+	r.log("[reverse-relay] session id=%s device_port=%d local=%s", session.RelayID, devicePort, localAddr)
+
+	go r.acceptLoop(runCtx, listener)
+	go r.readLoop(runCtx)
+
+	return localAddr, nil
+}
+
+// acceptLoop accepts local connections (from `flutter attach`) and bridges each
+// to the device through the relay.
+func (r *ReverseRelayTunnelBackend) acceptLoop(ctx context.Context, listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			r.log("[reverse-relay] accept error: %v", err)
+			return
+		}
+		go r.handleLocalConn(ctx, conn)
+	}
+}
+
+func (r *ReverseRelayTunnelBackend) handleLocalConn(ctx context.Context, conn net.Conn) {
+	streamID := uuid.NewString()
+
+	r.streamMu.Lock()
+	r.streams[streamID] = conn
+	r.streamMu.Unlock()
+
+	defer func() {
+		r.streamMu.Lock()
+		delete(r.streams, streamID)
+		r.streamMu.Unlock()
+		_ = conn.Close()
+	}()
+
+	if err := r.sendEnvelope(relayEnvelope{Kind: reverseKindDialStart, StreamID: streamID}); err != nil {
+		r.log("[reverse-relay] failed to open device stream: %v", err)
+		return
+	}
+
+	buf := make([]byte, relayChunkSize)
+	for {
+		n, readErr := conn.Read(buf)
+		if n > 0 {
+			chunk := base64.StdEncoding.EncodeToString(buf[:n])
+			if err := r.sendEnvelope(relayEnvelope{
+				Kind:         reverseKindData,
+				StreamID:     streamID,
+				BodyChunkB64: chunk,
+			}); err != nil {
+				return
+			}
+		}
+		if readErr != nil {
+			if readErr != io.EOF && ctx.Err() == nil {
+				r.log("[reverse-relay] local read error: %v", readErr)
+			}
+			_ = r.sendEnvelope(relayEnvelope{Kind: reverseKindClose, StreamID: streamID})
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+	}
+}
+
+// readLoop pumps device->laptop bytes from the relay back into local conns.
+func (r *ReverseRelayTunnelBackend) readLoop(ctx context.Context) {
+	r.mu.Lock()
+	conn := r.conn
+	r.mu.Unlock()
+	if conn == nil {
+		return
+	}
+	for {
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			if ctx.Err() == nil {
+				r.log("[reverse-relay] websocket disconnected: %v", err)
+			}
+			return
+		}
+		var env relayEnvelope
+		if err := json.Unmarshal(message, &env); err != nil {
+			r.log("[reverse-relay] failed to decode message: %v", err)
+			continue
+		}
+		r.handleEnvelope(env)
+	}
+}
+
+func (r *ReverseRelayTunnelBackend) handleEnvelope(env relayEnvelope) {
+	switch env.Kind {
+	case reverseKindData:
+		r.streamMu.Lock()
+		conn := r.streams[env.StreamID]
+		r.streamMu.Unlock()
+		if conn == nil {
+			return
+		}
+		chunk, err := base64.StdEncoding.DecodeString(env.BodyChunkB64)
+		if err != nil {
+			_ = conn.Close()
+			return
+		}
+		_, _ = conn.Write(chunk)
+	case reverseKindClose, reverseKindError:
+		r.streamMu.Lock()
+		conn := r.streams[env.StreamID]
+		delete(r.streams, env.StreamID)
+		r.streamMu.Unlock()
+		if conn != nil {
+			_ = conn.Close()
+		}
+	case "ping":
+		_ = r.sendEnvelope(relayEnvelope{Kind: "pong"})
+	}
+}
+
+func (r *ReverseRelayTunnelBackend) sendEnvelope(env relayEnvelope) error {
+	r.mu.Lock()
+	conn := r.conn
+	r.mu.Unlock()
+	if conn == nil {
+		return fmt.Errorf("reverse relay websocket is not connected")
+	}
+
+	payload, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("failed to encode reverse relay message: %w", err)
+	}
+
+	r.writeMu.Lock()
+	defer r.writeMu.Unlock()
+	return conn.WriteMessage(websocket.TextMessage, payload)
+}
+
+// StopReverse tears down the local listener, websocket, and relay session.
+func (r *ReverseRelayTunnelBackend) StopReverse() error {
+	r.mu.Lock()
+	if r.stopped {
+		r.mu.Unlock()
+		return nil
+	}
+	r.stopped = true
+	cancel := r.cancel
+	listener := r.listener
+	conn := r.conn
+	session := r.session
+	r.listener = nil
+	r.conn = nil
+	r.session = nil
+	r.localAddr = ""
+	r.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if listener != nil {
+		_ = listener.Close()
+	}
+	if conn != nil {
+		_ = conn.Close()
+	}
+
+	r.streamMu.Lock()
+	streams := r.streams
+	r.streams = make(map[string]net.Conn)
+	r.streamMu.Unlock()
+	for _, c := range streams {
+		_ = c.Close()
+	}
+
+	if session != nil && r.client != nil {
+		if err := r.client.RevokeHotReloadRelay(context.Background(), session.RelayID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/hotreload/reverse_relay_test.go
+++ b/internal/hotreload/reverse_relay_test.go
@@ -1,0 +1,142 @@
+package hotreload
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/revyl/cli/internal/api"
+)
+
+func TestReverseRelayStartRequiresClient(t *testing.T) {
+	backend := NewReverseRelayTunnelBackend(nil, "flutter", "ios")
+	if _, err := backend.StartReverse(context.Background(), 1234); err == nil {
+		t.Fatal("StartReverse with nil client should error")
+	}
+}
+
+func TestReverseRelayStartRequiresPositivePort(t *testing.T) {
+	backend := NewReverseRelayTunnelBackend(&api.Client{}, "flutter", "ios")
+	if _, err := backend.StartReverse(context.Background(), 0); err == nil {
+		t.Fatal("StartReverse with non-positive device port should error")
+	}
+}
+
+func TestReverseRelayStopBeforeStartIsNoop(t *testing.T) {
+	backend := NewReverseRelayTunnelBackend(&api.Client{}, "flutter", "ios")
+	if err := backend.StopReverse(); err != nil {
+		t.Fatalf("StopReverse before start should be a no-op, got %v", err)
+	}
+	if addr := backend.LocalAddr(); addr != "" {
+		t.Fatalf("LocalAddr should be empty before start, got %q", addr)
+	}
+}
+
+// TestReverseRelayProxyRoundTrip stands up a fake backend that echoes device
+// data back, then verifies bytes written to the local proxy address come back
+// through the relay. This exercises the full CLI-side data plane without a real
+// device.
+func TestReverseRelayProxyRoundTrip(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/hotreload/relays", func(w http.ResponseWriter, r *http.Request) {
+		session := api.HotReloadRelaySession{
+			RelayID:      "relay-test",
+			PublicURL:    "https://example.invalid",
+			ConnectURL:   "ws://" + r.Host + "/relay-ws",
+			ConnectToken: "token",
+			Transport:    api.HotReloadRelayModeReverse,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(session)
+	})
+	mux.HandleFunc("/relay-ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			_, message, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			var env relayEnvelope
+			if err := json.Unmarshal(message, &env); err != nil {
+				continue
+			}
+			// Echo device data back to the laptop, simulating the device.
+			if env.Kind == reverseKindData {
+				_ = conn.WriteJSON(relayEnvelope{
+					Kind:         reverseKindData,
+					StreamID:     env.StreamID,
+					BodyChunkB64: env.BodyChunkB64,
+				})
+			}
+		}
+	})
+	mux.HandleFunc("/api/v1/hotreload/relays/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := api.NewClientWithBaseURL("test-key", server.URL)
+	backend := NewReverseRelayTunnelBackend(client, "flutter", "ios")
+
+	localAddr, err := backend.StartReverse(context.Background(), 8181)
+	if err != nil {
+		t.Fatalf("StartReverse error: %v", err)
+	}
+	defer backend.StopReverse()
+
+	if backend.LocalAddr() != localAddr {
+		t.Fatalf("LocalAddr mismatch: %q vs %q", backend.LocalAddr(), localAddr)
+	}
+
+	conn, err := net.DialTimeout("tcp", localAddr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial local proxy: %v", err)
+	}
+	defer conn.Close()
+
+	payload := []byte("vm-service-handshake")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write to proxy: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	buf := make([]byte, len(payload))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("read echoed bytes: %v", err)
+	}
+	if string(buf[:n]) != string(payload) {
+		t.Fatalf("round-trip mismatch: got %q want %q", string(buf[:n]), string(payload))
+	}
+}
+
+func TestReverseRelayEnvelopeEncoding(t *testing.T) {
+	// Guard against accidental field-tag changes that would break the wire format.
+	env := relayEnvelope{Kind: reverseKindData, StreamID: "s1", BodyChunkB64: base64.StdEncoding.EncodeToString([]byte("x"))}
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded relayEnvelope
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Kind != reverseKindData || decoded.StreamID != "s1" {
+		t.Fatalf("round-trip decode mismatch: %+v", decoded)
+	}
+}

--- a/internal/hotreload/tunnel.go
+++ b/internal/hotreload/tunnel.go
@@ -39,6 +39,30 @@ type TunnelBackendInfoProvider interface {
 	Metadata() TunnelBackendInfo
 }
 
+// ReverseTunnelBackend exposes a REMOTE port on the cloud device as a LOCAL
+// address on the developer's machine.
+//
+// This is the mirror image of TunnelBackend. Where TunnelBackend lets the
+// device reach a local port on the laptop (device -> laptop, used by the
+// Metro/JS dev loop), ReverseTunnelBackend lets the laptop reach a port on the
+// device (laptop -> device). It is required by attach-based dev loops such as
+// Flutter, where the host tool (`flutter attach`) must connect into the Dart
+// VM Service that the running app exposes on the device.
+//
+// The returned localAddr is a "host:port" on 127.0.0.1 that proxies, byte for
+// byte, to devicePort on the cloud device through the backend relay.
+type ReverseTunnelBackend interface {
+	// StartReverse opens a local listener and bridges it to devicePort on the
+	// cloud device. It returns the local "host:port" the caller should dial.
+	StartReverse(ctx context.Context, devicePort int) (localAddr string, err error)
+
+	// StopReverse tears down the local listener and the relay session.
+	StopReverse() error
+
+	// LocalAddr returns the current local proxy address, or "" if not running.
+	LocalAddr() string
+}
+
 // RelayReacquireResult describes a replacement relay session created in place.
 type RelayReacquireResult struct {
 	TunnelURL string


### PR DESCRIPTION
## Summary

Builds the **entire CLI side** of Flutter hot reload on cloud devices, using **reverse forwarding** so the laptop can reach the device's Dart VM Service through the relay (the mirror of how JS works, where the device pulls from the laptop).

Everything here is **additive and gated** — `FlutterProvider.IsSupported()` stays `false` and the `revyl dev` path is behind `REVYL_FLUTTER_HOT_RELOAD`. **No behavior changes for users**; Flutter still routes to the rebuild loop by default. This is a reviewable, self-contained foundation that is validated end-to-end locally and ready to plug into backend support.

### Why
The relay only flows device→laptop (the device pulls bundles — perfect for Metro/JS). Flutter's `flutter attach` needs the opposite: the host connects *into* the device's VM Service. The data plane is already bidirectional; what's missing is **laptop-initiated streams targeting a device-side port** (reverse forwarding). This PR builds the laptop half of that plus the full reload loop.

## What's included

**Transport (reverse forwarding)**
- `ReverseTunnelBackend` interface (`internal/hotreload/tunnel.go`) — expose a *device* port as a *local* address.
- `ReverseRelayTunnelBackend` (`internal/hotreload/reverse_relay.go`) — a local TCP listener that proxies raw bytes to the device's VM Service port over the relay websocket. A twin of `relay.go`; raw TCP so it carries the VM Service's HTTP/websocket traffic transparently.
- API params (`internal/api/client.go`) — reverse-mode relay request (`Mode`, `DevicePort`) and `DeviceVMServicePort` on the session.

**Attach dev server + reload loop**
- `FlutterAttachDevServer` (`internal/hotreload/providers/flutter_devserver.go`) — drives `flutter attach`, issues hot reload (`r`) / hot restart (`R`), supports `-d <deviceId>`.
- `Reloadable`, `DebugURLConfigurable`, `DeviceIDConfigurable` interfaces (`internal/hotreload/devserver.go`).
- `ReloadDriver` + `ClassifyFlutterChange` (`internal/hotreload/reload_driver.go`) — file changes → classify (.dart→reload, pubspec/native→rebuild, else→none) → drive the dev server.
- `Manager` attach orchestration (`internal/hotreload/manager.go`) — `startAttach` establishes the reverse tunnel (or a local debug URL) and launches attach, then **self-assembles** the FileWatcher→ReloadDriver→Reload loop. `Manager.Reload`/`HotRestart` for manual triggers.
- Provider wiring (`internal/hotreload/provider.go`, `providers/flutter_provider.go`) — `ProviderDevLoopStyler`; Flutter reports `DevLoopStyle() == "attach"`.

**`revyl dev` integration (gated)**
- `runDevFlutterAttach` (`cmd/revyl/dev.go`) — opt in via `REVYL_FLUTTER_HOT_RELOAD`; local path attaches to a running VM Service via `REVYL_FLUTTER_DEBUG_URL` (+ optional `REVYL_FLUTTER_DEVICE`). Interactive keys: `[r]` reload, `[R]` restart, `[q]`/Ctrl+C quit. No public CLI flags added.

**Build**
- Flutter iOS build now defaults to `flutter build ios --simulator --debug` (`internal/build/detect.go`) — release builds disable the Dart VM Service. Also aligns code with the already-correct docs (`artifact-requirements.md`, `flutter.md`).

**Docs**
- `docs/developer_loop/flutter-hot-reload-design.md` — the backend contract + open questions.

## Validation

Validated **end-to-end through the real `revyl dev` binary** on an iPhone 17 Pro simulator (Flutter 3.44.2): editing `lib/main.dart` hot reloaded the device in ~200ms (`Reloaded 1 of 753 libraries in 224ms`). Gate verified on (reaches the runner) and off (dormant). The reverse relay is intentionally not exercised here (local device), which de-risks the attach/reload mechanics independent of the backend.

`go build ./...`, `go vet ./...`, `gofmt`, and `go test ./...` all pass. New goroutine-heavy code is `-race` clean.

## Not in this PR (blocked on backend, not this repo)

1. **Reverse-mode relay** — accept CLI-initiated streams and dial the device VM Service port.
2. **VM Service port discovery** — feeds the `SetDeviceVMServicePort` seam (the cloud path in `runDevFlutterAttach` currently returns a clear "not available yet" error).

Once those land: wire discovery → `SetDeviceVMServicePort`, flip `IsSupported()` / the capability gate to default-on, and update the support tables in `dev-setup.md` / `builds/index.md` / `dev-loop.md`. See the design doc for the contract + 4 open questions.

## Known notes
- `FlutterWatchConfig` excludes `ios/`/`android/` dirs (pre-existing), so native-source edits don't surface the rebuild message — only `pubspec` changes do. `ClassifyFlutterChange` handles native paths correctly when seen.
- A pre-existing `-race` failure in `TestManagerStartExpoLogsDetailedInDebugMode` is unrelated (reproduces without this branch; CI does not run `-race`).

## Commits
1. scaffold reverse-relay transport + attach dev server + wiring + design doc
2. Manager attach orchestration (gated)
3. file-change reload driver
4. device-id support + live e2e PoC test
5. self-assemble the reload loop in the Manager
6. gated `revyl dev` routing
7. Flutter iOS `--debug` build fix
8. interactive `[r]`/`[R]`/`[q]` keys + rebuild messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)