### PR TITLE
fix: send nested request body for workflow config set

### DIFF
--- a/cmd/revyl/workflow_settings.go
+++ b/cmd/revyl/workflow_settings.go
@@ -550,7 +550,7 @@ func runWorkflowConfigSet(cmd *cobra.Command, args []string) error {
 	}
 
 	ui.StartSpinner("Updating run config...")
-	err = client.UpdateWorkflowRunConfig(cmd.Context(), workflowID, cfg)
+	err = client.UpdateWorkflowRunConfig(cmd.Context(), workflowID, cfg, true)
 	ui.StopSpinner()
 
 	if err != nil {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3577,6 +3577,7 @@ type Workflow struct {
 	BuildConfig         map[string]interface{} `json:"build_config,omitempty"`
 	OverrideBuildConfig bool                   `json:"override_build_config,omitempty"`
 	RunConfig           *WorkflowRunConfig     `json:"run_config,omitempty"`
+	OverrideRunConfig   bool                   `json:"override_run_config,omitempty"`
 }
 
 // CLIWorkflowLastExecution holds the last execution metadata returned by the
@@ -5447,12 +5448,26 @@ type WorkflowRunConfig struct {
 //   - ctx: Context for cancellation
 //   - workflowID: The workflow UUID
 //   - config: The run configuration to apply
+//   - override: Whether to override inherited run config from project defaults
 //
 // Returns:
 //   - error: Any error that occurred
-func (c *Client) UpdateWorkflowRunConfig(ctx context.Context, workflowID string, config *WorkflowRunConfig) error {
+func (c *Client) UpdateWorkflowRunConfig(ctx context.Context, workflowID string, config *WorkflowRunConfig, override bool) error {
+	runConfig := map[string]interface{}{}
+	if config != nil {
+		if config.Parallelism > 0 {
+			runConfig["parallelism"] = config.Parallelism
+		}
+		if config.MaxRetries >= 0 {
+			runConfig["max_retries"] = config.MaxRetries
+		}
+	}
+	body := map[string]interface{}{
+		"run_config":          runConfig,
+		"override_run_config": override,
+	}
 	path := fmt.Sprintf("/api/v1/workflows/update_run_config/%s", workflowID)
-	resp, err := c.doRequest(ctx, "PUT", path, config)
+	resp, err := c.doRequest(ctx, "PUT", path, body)
 	if err != nil {
 		return err
 	}

--- a/internal/tui/workflow_mgmt.go
+++ b/internal/tui/workflow_mgmt.go
@@ -1368,7 +1368,7 @@ func saveWorkflowOverridesCmd(client *api.Client, workflowID string, wf *api.Wor
 			return WorkflowSettingsSavedMsg{Err: err}
 		}
 		if wf.RunConfig != nil {
-			if err := client.UpdateWorkflowRunConfig(ctx, workflowID, wf.RunConfig); err != nil {
+			if err := client.UpdateWorkflowRunConfig(ctx, workflowID, wf.RunConfig, wf.OverrideRunConfig); err != nil {
 				return WorkflowSettingsSavedMsg{Err: err}
 			}
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes REV-377: CLI `workflow config set` command was failing with validation error:
```
✗ Failed to update run config: Validation error: body.run_config: Field required; body.override_run_config: Field required
```

## Problem

The CLI was sending a flat request body to `/api/v1/workflows/update_run_config/{workflow_id}`:
```json
{"parallelism": 3, "max_retries": 1}
```

But the backend expects a nested structure:
```json
{"run_config": {"parallelism": 3, "max_retries": 1}, "override_run_config": true}
```

## Solution

Updated `UpdateWorkflowRunConfig` in `internal/api/client.go` to:
1. Accept an `override bool` parameter (consistent with sibling methods like `UpdateWorkflowLocationConfig` and `UpdateWorkflowBuildConfig`)
2. Wrap the config in the expected nested body structure with `run_config` and `override_run_config` fields

Also updated all callers:
- CLI command (`cmd/revyl/workflow_settings.go`) - passes `override=true`
- TUI (`internal/tui/workflow_mgmt.go`) - passes `wf.OverrideRunConfig`

Added `OverrideRunConfig` field to the `Workflow` struct for consistency with other config types.

## Testing

- All existing tests pass
- The command `revyl workflow config set <workflow> --parallel 3 --retries 1` will now send the correct nested body structure
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [REV-377](https://linear.app/revyl/issue/REV-377/cli-workflow-config-set-sends-wrong-request-body)

<div><a href="https://cursor.com/agents/bc-3bfbd09a-af97-42a3-84ad-806fe435d8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bfbd09a-af97-42a3-84ad-806fe435d8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

