### PR TITLE
fix(cli): nest workflow run config in update_run_config request body

### DIFF
--- a/cmd/revyl/workflow_settings.go
+++ b/cmd/revyl/workflow_settings.go
@@ -550,7 +550,7 @@ func runWorkflowConfigSet(cmd *cobra.Command, args []string) error {
 	}
 
 	ui.StartSpinner("Updating run config...")
-	err = client.UpdateWorkflowRunConfig(cmd.Context(), workflowID, cfg)
+	err = client.UpdateWorkflowRunConfig(cmd.Context(), workflowID, cfg, true)
 	ui.StopSpinner()
 
 	if err != nil {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3577,6 +3577,7 @@ type Workflow struct {
 	BuildConfig         map[string]interface{} `json:"build_config,omitempty"`
 	OverrideBuildConfig bool                   `json:"override_build_config,omitempty"`
 	RunConfig           *WorkflowRunConfig     `json:"run_config,omitempty"`
+	OverrideRunConfig   bool                   `json:"override_run_config,omitempty"`
 }
 
 // CLIWorkflowLastExecution holds the last execution metadata returned by the
@@ -5447,12 +5448,24 @@ type WorkflowRunConfig struct {
 //   - ctx: Context for cancellation
 //   - workflowID: The workflow UUID
 //   - config: The run configuration to apply
+//   - override: Whether workflow-level run config overrides org defaults
 //
 // Returns:
 //   - error: Any error that occurred
-func (c *Client) UpdateWorkflowRunConfig(ctx context.Context, workflowID string, config *WorkflowRunConfig) error {
+func (c *Client) UpdateWorkflowRunConfig(ctx context.Context, workflowID string, config *WorkflowRunConfig, override bool) error {
+	runConfig := map[string]interface{}{}
+	if config != nil {
+		if config.Parallelism > 0 {
+			runConfig["parallelism"] = config.Parallelism
+		}
+		runConfig["max_retries"] = config.MaxRetries
+	}
+	body := map[string]interface{}{
+		"run_config":          runConfig,
+		"override_run_config": override,
+	}
 	path := fmt.Sprintf("/api/v1/workflows/update_run_config/%s", workflowID)
-	resp, err := c.doRequest(ctx, "PUT", path, config)
+	resp, err := c.doRequest(ctx, "PUT", path, body)
 	if err != nil {
 		return err
 	}

--- a/internal/tui/workflow_mgmt.go
+++ b/internal/tui/workflow_mgmt.go
@@ -1368,7 +1368,7 @@ func saveWorkflowOverridesCmd(client *api.Client, workflowID string, wf *api.Wor
 			return WorkflowSettingsSavedMsg{Err: err}
 		}
 		if wf.RunConfig != nil {
-			if err := client.UpdateWorkflowRunConfig(ctx, workflowID, wf.RunConfig); err != nil {
+			if err := client.UpdateWorkflowRunConfig(ctx, workflowID, wf.RunConfig, wf.OverrideRunConfig); err != nil {
 				return WorkflowSettingsSavedMsg{Err: err}
 			}
 		}
@@ -1749,6 +1749,7 @@ func applySettingsEdit(m *hubModel) {
 		n := 0
 		fmt.Sscanf(val, "%d", &n)
 		wf.RunConfig.Parallelism = n
+		wf.OverrideRunConfig = true
 		m.wfSettingsDirty = true
 	case "max_retries":
 		if wf.RunConfig == nil {
@@ -1757,6 +1758,7 @@ func applySettingsEdit(m *hubModel) {
 		n := 0
 		fmt.Sscanf(val, "%d", &n)
 		wf.RunConfig.MaxRetries = n
+		wf.OverrideRunConfig = true
 		m.wfSettingsDirty = true
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes REV-377: `revyl workflow config set` failed with validation errors because the CLI sent a flat run-config payload instead of the nested shape the API expects.

## Changes

- Wrap `UpdateWorkflowRunConfig` body as `{ "run_config": { ... }, "override_run_config": <bool> }`, consistent with `UpdateWorkflowLocationConfig` and `UpdateWorkflowBuildConfig`.
- CLI `workflow config set` passes `override_run_config: true` when applying parallelism/retries.
- TUI workflow settings pass `wf.OverrideRunConfig` and set it when editing parallelism or max retries.
- Add `OverrideRunConfig` to the `Workflow` API model for parity with other override flags.

## Test plan

- [x] `go test ./internal/api/... ./cmd/revyl/... ./internal/tui/...`
- [ ] `revyl workflow config set <workflow> --parallel 3 --retries 1` against staging/production API
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [REV-377](https://linear.app/revyl/issue/REV-377/cli-workflow-config-set-sends-wrong-request-body)

<div><a href="https://cursor.com/agents/bc-d02461ae-ff7b-4fe6-a7c2-ecf7ae4ea91e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d02461ae-ff7b-4fe6-a7c2-ecf7ae4ea91e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

